### PR TITLE
add task-05 player leveling progression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this repository should be documented in this file.
+
+The canonical repository version lives in `Cargo.toml` under `[workspace.package].version` and follows SemVer.
+
+## [Unreleased]
+
+### Added
+- Level-based player progression driven by server-authoritative XP thresholds and stat scaling.
+- Snapshot propagation of progression fields (`level`, `xp`, `next_level_xp`, `skill_points`) for synchronized client state.
+- Local HUD progression readout for level, XP progress, and available skill points.
+
+## [0.2.0] - 2026-04-01
+
+### Added
+- Implemented TASK-05 player leveling and stat progression, including XP thresholds, level-up scaling for HP/mana, and respawn compatibility with upgraded stats.
+- Added progression-oriented server tests covering multi-level XP transitions and respawn behavior after scaling.
+- Added client progression ingestion and HUD presentation of progression state.
+
+## [0.1.0] - 2026-04-01
+
+### Added
+- Initial repository version baseline from `[workspace.package].version`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bevy",
  "crossbeam-channel",
@@ -4706,7 +4706,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["client", "server"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [workspace.dependencies]

--- a/client/src/net.rs
+++ b/client/src/net.rs
@@ -13,9 +13,11 @@ use std::{
 use crate::camera::{CameraState, MainCamera, locked_camera_offset};
 use crate::combat::{CombatStats, MAX_HP, MAX_MANA};
 use crate::player::{PLAYER_SIZE, Player, PlayerBody, VerticalVelocity};
-use crate::team::{CharacterChoice, Team};
 use crate::team::TeamSelection;
-use crate::world::{NormalizeModelScale, PlayerAssets, PlayerModelCatalog, model_assets_for_choice};
+use crate::team::{CharacterChoice, Team};
+use crate::world::{
+    NormalizeModelScale, PlayerAssets, PlayerModelCatalog, model_assets_for_choice,
+};
 
 const DEFAULT_SERVER_ADDR: &str = "127.0.0.1:4000";
 const LOCAL_BIND_ADDR: &str = "0.0.0.0:0";
@@ -30,6 +32,8 @@ const BASE_TOWER_SIZE: f32 = 6.0;
 const BASE_TOWER_HEIGHT: f32 = 8.0;
 const MINION_RADIUS: f32 = 0.55;
 const LOCAL_SNAP_DISTANCE: f32 = 4.0;
+const DEFAULT_PLAYER_LEVEL: u32 = 1;
+const DEFAULT_NEXT_LEVEL_XP: u32 = 120;
 
 pub struct NetworkingPlugin;
 
@@ -61,15 +65,27 @@ impl Plugin for NetworkingPlugin {
 
 #[derive(Message, Clone, Copy, Debug)]
 pub enum NetworkCommand {
-    Cast { target: TargetId },
-    Join { team: Team, character: CharacterChoice },
+    Cast {
+        target: TargetId,
+    },
+    Join {
+        team: Team,
+        character: CharacterChoice,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum ClientPacket {
-    Transform { x: f32, y: f32, z: f32, yaw: f32 },
-    Cast { target: TargetId },
+    Transform {
+        x: f32,
+        y: f32,
+        z: f32,
+        yaw: f32,
+    },
+    Cast {
+        target: TargetId,
+    },
     Join {
         team: Team,
         #[serde(default = "default_character_choice")]
@@ -113,6 +129,12 @@ struct PlayerState {
     gold: u32,
     #[serde(default)]
     xp: u32,
+    #[serde(default = "default_player_level")]
+    level: u32,
+    #[serde(default = "default_next_level_xp")]
+    next_level_xp: u32,
+    #[serde(default)]
+    skill_points: u32,
     #[serde(default = "default_character_choice")]
     character: CharacterChoice,
 }
@@ -253,6 +275,14 @@ pub struct NetworkPlayerId(pub u64);
 
 #[derive(Component, Clone, Copy, Debug)]
 pub struct NetworkCharacterChoice(pub CharacterChoice);
+
+#[derive(Component, Clone, Copy, Debug, Default)]
+pub struct PlayerProgression {
+    pub level: u32,
+    pub xp: u32,
+    pub next_level_xp: u32,
+    pub skill_points: u32,
+}
 
 #[derive(Component)]
 struct NetworkProjectile;
@@ -435,7 +465,9 @@ fn run_udp_client(
                 Ok(len) => match serde_json::from_slice::<ServerPacket>(&recv_buf[..len]) {
                     Ok(packet) => {
                         if !first_snapshot_received {
-                            println!("First snapshot received from {server_addr}; connection is live");
+                            println!(
+                                "First snapshot received from {server_addr}; connection is live"
+                            );
                             first_snapshot_received = true;
                         }
                         let _ = incoming.send(packet);
@@ -614,7 +646,9 @@ fn apply_server_snapshot(
         }
 
         // Always ensure the local player is tagged with the server-provided id.
-        commands.entity(local_entity).insert(NetworkPlayerId(your_id));
+        commands
+            .entity(local_entity)
+            .insert(NetworkPlayerId(your_id));
 
         // Only apply character/team/stats once we actually have a state entry for our id.
         // Otherwise we'd oscillate between the locally selected character and the server default.
@@ -623,6 +657,7 @@ fn apply_server_snapshot(
                 local_player_state.team,
                 player_state_to_combat_stats(local_player_state),
                 NetworkCharacterChoice(local_player_state.character),
+                player_state_to_progression(local_player_state),
             ));
             network_state.local_team = Some(local_player_state.team);
 
@@ -677,6 +712,7 @@ fn apply_server_snapshot(
                     NetworkPlayerId(your_id),
                     NetworkCharacterChoice(local_player_state.character),
                     player_state_to_combat_stats(local_player_state),
+                    player_state_to_progression(local_player_state),
                     Name::new("Player"),
                 ))
                 .id()
@@ -693,6 +729,7 @@ fn apply_server_snapshot(
                     NetworkPlayerId(your_id),
                     NetworkCharacterChoice(local_player_state.character),
                     player_state_to_combat_stats(local_player_state),
+                    player_state_to_progression(local_player_state),
                     Name::new("Player"),
                 ))
                 .id()
@@ -735,11 +772,13 @@ fn apply_server_snapshot(
                 player.team,
                 NetworkCharacterChoice(player.character),
                 player_state_to_combat_stats(player),
+                player_state_to_progression(player),
             ));
             continue;
         }
 
-        let (scene_handle, _gltf_handle) = model_assets_for_choice(&model_catalog, player.character);
+        let (scene_handle, _gltf_handle) =
+            model_assets_for_choice(&model_catalog, player.character);
         let mesh_handle = player_assets.mesh.clone();
         let material_handle = player_assets.material.clone();
         let spawn_translation = Vec3::new(player.x, player.y, player.z);
@@ -754,6 +793,7 @@ fn apply_server_snapshot(
             NetworkCharacterChoice(player.character),
             NormalizeModelScale::for_player_model(),
             player_state_to_combat_stats(player),
+            player_state_to_progression(player),
             RemotePlayerInterpolation {
                 from_translation: spawn_translation,
                 to_translation: spawn_translation,
@@ -932,13 +972,11 @@ fn apply_server_snapshot(
                 };
                 commands.entity(entity).insert(interpolation);
             }
-            commands
-                .entity(entity)
-                .insert((
-                    NetworkMinionId(minion.id),
-                    minion.team,
-                    minion_state_to_combat_stats(minion),
-                ));
+            commands.entity(entity).insert((
+                NetworkMinionId(minion.id),
+                minion.team,
+                minion_state_to_combat_stats(minion),
+            ));
             continue;
         }
 
@@ -1032,6 +1070,15 @@ fn player_state_to_combat_stats(player: &PlayerState) -> CombatStats {
     }
 }
 
+fn player_state_to_progression(player: &PlayerState) -> PlayerProgression {
+    PlayerProgression {
+        level: player.level.max(1),
+        xp: player.xp,
+        next_level_xp: player.next_level_xp,
+        skill_points: player.skill_points,
+    }
+}
+
 fn structure_state_to_combat_stats(structure: &StructureState) -> CombatStats {
     CombatStats {
         hp: structure.hp,
@@ -1060,6 +1107,14 @@ fn default_team() -> Team {
 
 fn default_character_choice() -> CharacterChoice {
     CharacterChoice::Ipfs
+}
+
+fn default_player_level() -> u32 {
+    DEFAULT_PLAYER_LEVEL
+}
+
+fn default_next_level_xp() -> u32 {
+    DEFAULT_NEXT_LEVEL_XP
 }
 
 fn default_max_hp() -> f32 {

--- a/client/src/player.rs
+++ b/client/src/player.rs
@@ -11,11 +11,11 @@ use std::f32::consts::PI;
 use crate::camera::{CameraState, MainCamera};
 use crate::combat::{CombatStats, MAX_HP};
 use crate::debug_console::DebugConsole;
-use crate::minimap::MinimapNavigationState;
 use crate::maps::MapLayout;
+use crate::minimap::MinimapNavigationState;
 use crate::net::{
-    GameState, GameStateSnapshot, NetworkCharacterChoice, NetworkStructure, RemotePlayer,
-    StructureKind,
+    GameState, GameStateSnapshot, NetworkCharacterChoice, NetworkStructure, PlayerProgression,
+    RemotePlayer, StructureKind,
 };
 use crate::team::{CharacterChoice, Team};
 use crate::world::{PlayerModelCatalog, model_assets_for_choice};
@@ -54,8 +54,8 @@ impl Plugin for PlayerPlugin {
         .add_systems(PostUpdate, apply_gravity)
         .init_resource::<RespawnCountdown>()
         .init_resource::<PlayerAnimationLibrary>()
-        .add_systems(Startup, setup_respawn_ui)
-        .add_systems(Update, respawn_countdown_system);
+        .add_systems(Startup, (setup_respawn_ui, setup_progression_ui))
+        .add_systems(Update, (respawn_countdown_system, progression_hud_system));
     }
 }
 
@@ -87,6 +87,9 @@ impl Default for RespawnCountdown {
 
 #[derive(Component)]
 struct RespawnCountdownText;
+
+#[derive(Component)]
+struct ProgressionHudText;
 
 #[derive(Component)]
 struct MovementTarget {
@@ -152,7 +155,11 @@ fn setup_player_animation_library(
     let Some(catalog) = catalog else {
         return;
     };
-    for character in [CharacterChoice::Ipfs, CharacterChoice::Toka, CharacterChoice::Wang] {
+    for character in [
+        CharacterChoice::Ipfs,
+        CharacterChoice::Toka,
+        CharacterChoice::Wang,
+    ] {
         let (_scene, maybe_gltf) = model_assets_for_choice(&catalog, character);
         let Some(gltf_handle) = maybe_gltf else {
             // No GLTF means no skeletal animations — mark evaluated so jump fallback activates.
@@ -174,9 +181,11 @@ fn setup_player_animation_library(
         let find_clip = |substrings: &[&str]| -> Option<(String, Handle<AnimationClip>)> {
             for needle in substrings {
                 if let Some((animation_name, handle)) =
-                    gltf.named_animations.iter().find(|(animation_name, _handle)| {
-                        animation_name.to_ascii_lowercase().contains(needle)
-                    })
+                    gltf.named_animations
+                        .iter()
+                        .find(|(animation_name, _handle)| {
+                            animation_name.to_ascii_lowercase().contains(needle)
+                        })
                 {
                     return Some((animation_name.to_string(), handle.clone()));
                 }
@@ -229,7 +238,9 @@ fn sync_jump_fallback_mode(
     players: Query<(Entity, Option<&NetworkCharacterChoice>, Option<&Jumping>), With<Player>>,
 ) {
     for (entity, character, jumping) in &players {
-        let character = character.map(|selected| selected.0).unwrap_or(CharacterChoice::Ipfs);
+        let character = character
+            .map(|selected| selected.0)
+            .unwrap_or(CharacterChoice::Ipfs);
         let should_jump_fallback = animation_library.should_use_jump_fallback(character);
         if !should_jump_fallback && jumping.is_some() {
             commands.entity(entity).remove::<Jumping>();
@@ -304,13 +315,11 @@ fn sync_player_animation_state(
     local_player_query: Query<(), With<Player>>,
     local_movement_query: Query<(Option<&MovementTarget>, Option<&Jumping>), With<Player>>,
     player_state_query: Query<(&Transform, &CombatStats), Or<(With<Player>, With<RemotePlayer>)>>,
-    mut animation_query: Query<
-        (
-            &mut AnimationPlayer,
-            &mut PlayerAnimationBinding,
-            &mut AnimationGraphHandle,
-        ),
-    >,
+    mut animation_query: Query<(
+        &mut AnimationPlayer,
+        &mut PlayerAnimationBinding,
+        &mut AnimationGraphHandle,
+    )>,
 ) {
     if !library.has_locomotion_animations() {
         return;
@@ -354,7 +363,9 @@ fn sync_player_animation_state(
             animation_player.play(active_node).repeat();
         }
 
-        let distance = owner_transform.translation.distance(binding.last_owner_position);
+        let distance = owner_transform
+            .translation
+            .distance(binding.last_owner_position);
         let speed = distance / time.delta_secs().max(0.001);
         let moved = speed > 0.05;
         binding.last_owner_position = owner_transform.translation;
@@ -442,8 +453,9 @@ fn handle_player_input(
                             commands
                                 .entity(player_entity)
                                 .insert(MovementTarget { target: target_pos });
-                            let character =
-                                character.map(|selected| selected.0).unwrap_or(CharacterChoice::Ipfs);
+                            let character = character
+                                .map(|selected| selected.0)
+                                .unwrap_or(CharacterChoice::Ipfs);
                             if !animation_library.should_use_jump_fallback(character) {
                                 commands.entity(player_entity).remove::<Jumping>();
                             } else {
@@ -612,6 +624,61 @@ fn setup_respawn_ui(mut commands: Commands) {
                 RespawnCountdownText,
             ));
         });
+}
+
+fn setup_progression_ui(mut commands: Commands) {
+    commands
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                left: Val::Px(16.0),
+                top: Val::Px(16.0),
+                ..default()
+            },
+            Name::new("ProgressionHud"),
+        ))
+        .with_children(|parent| {
+            parent.spawn((
+                Text::new("Level --   XP --/--   Skill points --"),
+                TextFont {
+                    font_size: 24.0,
+                    ..default()
+                },
+                TextColor(Color::WHITE),
+                ProgressionHudText,
+            ));
+        });
+}
+
+fn progression_hud_system(
+    player_query: Query<&PlayerProgression, With<Player>>,
+    mut text_query: Query<&mut Text, With<ProgressionHudText>>,
+) {
+    let Ok(mut text) = text_query.single_mut() else {
+        return;
+    };
+
+    let Some(progression) = player_query.iter().next() else {
+        text.0 = "Level --   XP --/--   Skill points --".to_string();
+        return;
+    };
+
+    if progression.next_level_xp == 0 {
+        text.0 = format!(
+            "Level {}   XP MAX   Skill points {}",
+            progression.level.max(1),
+            progression.skill_points
+        );
+    } else {
+        let displayed_xp = progression.xp.min(progression.next_level_xp);
+        text.0 = format!(
+            "Level {}   XP {}/{}   Skill points {}",
+            progression.level.max(1),
+            displayed_xp,
+            progression.next_level_xp,
+            progression.skill_points
+        );
+    }
 }
 
 fn respawn_countdown_system(

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,21 @@
+# Feature Inventory
+
+Canonical version: `0.2.0`
+
+## Current Playable Surface
+
+- Authoritative UDP server loop with periodic player snapshots.
+- Local multiplayer flow with server startup plus multi-client local play via `make start`.
+- Team join flow with character selection and player spawning.
+- Core combat loop with projectiles, structures, minions, death, respawn, mana regeneration, and base-destruction win condition.
+- Map layout with three lanes and simple jungle blocks.
+- Player progression with level-based XP thresholds, HP/mana scaling on level-up, and tracked skill points.
+- In-game local HUD display for level and XP progression.
+
+## Release Gaps Tracked In Tasks
+
+- Runtime and startup stability hardening.
+- Multiplayer session reliability and reconnect behavior.
+- Match phase, restart, and rematch flow.
+- Jungle camps and neutral AI.
+- Full skill system, tooltip UX, and release-readiness validation.

--- a/docs/progress/2026-04-01-task-05-player-leveling-and-stat-progression.md
+++ b/docs/progress/2026-04-01-task-05-player-leveling-and-stat-progression.md
@@ -1,0 +1,25 @@
+# Progress Report: Task 05 Player Leveling And Stat Progression
+
+- Date: 2026-04-01
+- Scope: implement server-authoritative XP leveling, stat scaling, snapshot propagation, and client HUD progression feedback
+
+## Changes
+
+- Added progression state fields to server player snapshots: `level`, `xp`, `next_level_xp`, and `skill_points`.
+- Introduced centralized progression tuning in server code (`LEVEL_XP_THRESHOLDS`, level cap, and per-level HP/mana bonuses).
+- Routed minion reward XP through progression logic so XP triggers automatic level-up transitions, including multi-level gains.
+- Extended client network snapshot mapping to ingest progression state and attach it as a player component.
+- Added HUD text that shows local player level, XP progress, and available skill points.
+- Added progression-focused server tests for level-up scaling and respawn behavior after scaling.
+
+## Checks
+
+- `cargo check` passed.
+- `cargo test` passed (client: 2 tests, server: 6 tests, including new progression tests).
+- `cargo test --tests` passed.
+- `cargo clippy --all-targets --all-features -- -D warnings` failed due pre-existing repository-wide lint debt in unchanged modules.
+
+## Remaining Risks
+
+- No dedicated automated multiplayer integration scenario currently validates cross-client visual confirmation of remote player level values in live sessions.
+- Strict clippy gating remains blocked by unrelated legacy lint violations; this task keeps its scope to progression implementation and validation.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -54,6 +54,11 @@ const MINIONS_PER_WAVE: usize = 3;
 const MINION_KILL_GOLD: u32 = 18;
 const MINION_KILL_XP: u32 = 32;
 const PLAYER_SPAWN_OFFSET: f32 = 7.0;
+const STARTING_LEVEL: u32 = 1;
+const MAX_LEVEL: u32 = 10;
+const LEVEL_UP_HP_BONUS: f32 = 18.0;
+const LEVEL_UP_MANA_BONUS: f32 = 12.0;
+const LEVEL_XP_THRESHOLDS: [u32; 9] = [120, 150, 180, 220, 260, 300, 340, 380, 420];
 
 const TARGET_BASE_RUN_TIME_SECONDS: f32 = 45.0;
 const PLAYER_SPEED: f32 = 5.0;
@@ -66,8 +71,15 @@ const LANE_EDGE_PADDING: f32 = 6.0;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum ClientPacket {
-    Transform { x: f32, y: f32, z: f32, yaw: f32 },
-    Cast { target: TargetId },
+    Transform {
+        x: f32,
+        y: f32,
+        z: f32,
+        yaw: f32,
+    },
+    Cast {
+        target: TargetId,
+    },
     Join {
         team: Team,
         #[serde(default = "default_character_choice")]
@@ -132,8 +144,52 @@ struct PlayerState {
     max_mana: f32,
     gold: u32,
     xp: u32,
+    level: u32,
+    next_level_xp: u32,
+    skill_points: u32,
     #[serde(default = "default_character_choice")]
     character: CharacterChoice,
+}
+
+fn xp_threshold_for_level(level: u32) -> u32 {
+    if level >= MAX_LEVEL {
+        0
+    } else {
+        let index = level.saturating_sub(STARTING_LEVEL) as usize;
+        LEVEL_XP_THRESHOLDS[index]
+    }
+}
+
+fn apply_level_up(state: &mut PlayerState) {
+    state.level = state.level.saturating_add(1);
+    state.skill_points = state.skill_points.saturating_add(1);
+    state.max_hp += LEVEL_UP_HP_BONUS;
+    state.max_mana += LEVEL_UP_MANA_BONUS;
+    state.hp = (state.hp + LEVEL_UP_HP_BONUS).clamp(0.0, state.max_hp);
+    state.mana = (state.mana + LEVEL_UP_MANA_BONUS).clamp(0.0, state.max_mana);
+    state.next_level_xp = xp_threshold_for_level(state.level);
+}
+
+fn grant_player_xp(state: &mut PlayerState, amount: u32) {
+    if amount == 0 {
+        return;
+    }
+    if state.level >= MAX_LEVEL {
+        state.xp = 0;
+        state.next_level_xp = 0;
+        return;
+    }
+
+    state.xp = state.xp.saturating_add(amount);
+    while state.level < MAX_LEVEL && state.next_level_xp > 0 && state.xp >= state.next_level_xp {
+        state.xp -= state.next_level_xp;
+        apply_level_up(state);
+    }
+
+    if state.level >= MAX_LEVEL {
+        state.xp = 0;
+        state.next_level_xp = 0;
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -575,6 +631,9 @@ fn ensure_player_connected(
                 max_mana: MAX_MANA,
                 gold: 0,
                 xp: 0,
+                level: STARTING_LEVEL,
+                next_level_xp: xp_threshold_for_level(STARTING_LEVEL),
+                skill_points: 0,
                 character: default_character_choice(),
             },
             last_seen: now,
@@ -620,6 +679,9 @@ fn handle_join_request(
     player.state.max_mana = MAX_MANA;
     player.state.gold = 0;
     player.state.xp = 0;
+    player.state.level = STARTING_LEVEL;
+    player.state.next_level_xp = xp_threshold_for_level(STARTING_LEVEL);
+    player.state.skill_points = 0;
     player.last_cast_at = None;
     player.respawn_at = None;
 }
@@ -778,8 +840,7 @@ fn simulate_projectiles(
                     return false;
                 };
 
-                let start =
-                    Vec3f::new(projectile.state.x, projectile.state.y, projectile.state.z);
+                let start = Vec3f::new(projectile.state.x, projectile.state.y, projectile.state.z);
                 let target_pos =
                     Vec3f::new(target.state.x, target.state.y + AIM_HEIGHT, target.state.z);
                 if projectile.homing {
@@ -818,8 +879,7 @@ fn simulate_projectiles(
                     return false;
                 }
 
-                let start =
-                    Vec3f::new(projectile.state.x, projectile.state.y, projectile.state.z);
+                let start = Vec3f::new(projectile.state.x, projectile.state.y, projectile.state.z);
                 let target_pos = Vec3f::new(
                     target_minion.state.x,
                     target_minion.state.y + MINION_RADIUS * 0.8,
@@ -868,8 +928,7 @@ fn simulate_projectiles(
                 if structure.state.hp <= 0.0 {
                     return false;
                 }
-                let start =
-                    Vec3f::new(projectile.state.x, projectile.state.y, projectile.state.z);
+                let start = Vec3f::new(projectile.state.x, projectile.state.y, projectile.state.z);
                 let target_pos =
                     Vec3f::new(structure.state.x, structure.state.y, structure.state.z);
                 if projectile.homing {
@@ -1334,7 +1393,7 @@ fn award_minion_kill_rewards(
             xp += 1;
         }
         player.state.gold = player.state.gold.saturating_add(gold);
-        player.state.xp = player.state.xp.saturating_add(xp);
+        grant_player_xp(&mut player.state, xp);
     }
 }
 
@@ -1821,6 +1880,60 @@ mod tests {
         regenerate_mana(&mut players, 100.0);
         let clamped = players.get(&addr).unwrap().state.mana;
         assert!((clamped - MAX_MANA).abs() < EPSILON);
+    }
+
+    #[test]
+    fn progression_levels_up_and_scales_stats() {
+        let layout = build_map_layout();
+        let mut players = HashMap::new();
+        let mut next_player_id = 1;
+        let addr: SocketAddr = "127.0.0.1:34568".parse().unwrap();
+        let now = Instant::now();
+
+        ensure_player_connected(&mut players, &layout, addr, &mut next_player_id, now);
+        let player = players.get_mut(&addr).unwrap();
+        let first_threshold = player.state.next_level_xp;
+        let second_threshold = xp_threshold_for_level(STARTING_LEVEL + 1);
+
+        grant_player_xp(&mut player.state, first_threshold + second_threshold + 17);
+
+        assert_eq!(player.state.level, STARTING_LEVEL + 2);
+        assert_eq!(player.state.skill_points, 2);
+        assert_eq!(player.state.xp, 17);
+        assert_eq!(
+            player.state.next_level_xp,
+            xp_threshold_for_level(STARTING_LEVEL + 2)
+        );
+        assert!((player.state.max_hp - (MAX_HP + LEVEL_UP_HP_BONUS * 2.0)).abs() < EPSILON);
+        assert!((player.state.max_mana - (MAX_MANA + LEVEL_UP_MANA_BONUS * 2.0)).abs() < EPSILON);
+    }
+
+    #[test]
+    fn respawn_restores_scaled_maximums() {
+        let layout = build_map_layout();
+        let structures = build_structures(&layout);
+        let mut players = HashMap::new();
+        let mut next_player_id = 1;
+        let addr: SocketAddr = "127.0.0.1:34569".parse().unwrap();
+        let now = Instant::now();
+
+        ensure_player_connected(&mut players, &layout, addr, &mut next_player_id, now);
+        let player = players.get_mut(&addr).unwrap();
+        let first_threshold = player.state.next_level_xp;
+        let second_threshold = xp_threshold_for_level(STARTING_LEVEL + 1);
+        grant_player_xp(&mut player.state, first_threshold + second_threshold);
+        player.state.hp = 0.0;
+        player.state.mana = 0.0;
+        player.respawn_at = Some(now - Duration::from_millis(1));
+
+        handle_respawns(&mut players, &structures, &layout, &GameState::Running, now);
+
+        let player = players.get(&addr).unwrap();
+        assert_eq!(player.state.level, STARTING_LEVEL + 2);
+        assert!(player.state.max_hp > MAX_HP);
+        assert!(player.state.max_mana > MAX_MANA);
+        assert!((player.state.hp - player.state.max_hp).abs() < EPSILON);
+        assert!((player.state.mana - player.state.max_mana).abs() < EPSILON);
     }
 }
 


### PR DESCRIPTION
Make XP progression server-authoritative so level and stat scaling remain consistent across snapshots and respawns, and expose progression state in the client HUD for transparent gameplay feedback.

Made-with: Cursor