### PR TITLE
TASK-11: deliver skill upgrades and tooltip truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The canonical repository version lives in `Cargo.toml` under `[workspace.package
 ## [Unreleased]
 
 ### Added
+- **TASK-11:** Shared `skills` crate for data-driven parameters; server-authoritative skill points (on level-up), ranks, and `UpgradeSkill` handling; client HUD bar with hover tooltips and Shift-based upgrade input; focused server and `skills` unit tests for progression and tooltip consistency.
 - Added a reproducible multiplayer session verification harness at `scripts/verify_task_02_multiplayer_session_flow.py` that exercises sequential and simultaneous joins, repeated joins, timeout cleanup, reconnect-as-new-player, server restart recovery, and four-client snapshot consistency against the live UDP server.
 - Added focused client coverage for authoritative local-player selection so duplicate local `Player` entities cannot silently break gameplay systems that rely on `Query::single()`.
 - Added multiplayer session policy documentation and a `TASK-02` progress log with the recorded session matrix.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,6 +1806,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "skills",
  "winit",
 ]
 
@@ -4710,6 +4711,7 @@ version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
+ "skills",
 ]
 
 [[package]]
@@ -4732,6 +4734,10 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "skills"
+version = "0.2.0"
 
 [[package]]
 name = "skrifa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["client", "server"]
+members = ["client", "server", "skills"]
 resolver = "2"
 
 [workspace.package]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,4 +9,5 @@ crossbeam-channel.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+skills = { path = "../skills" }
 winit.workspace = true

--- a/client/src/combat.rs
+++ b/client/src/combat.rs
@@ -14,7 +14,7 @@ use crate::debug_console::DebugConsole;
 use crate::net::{
     GameState, GameStateSnapshot, NetworkCommand, NetworkMinion, NetworkMinionId,
     NetworkNeutral, NetworkNeutralId, NetworkPlayerId, NetworkStructure, NetworkStructureId,
-    RemotePlayer, StructureKind, TargetId, TargetKind,
+    PlayerProgression, RemotePlayer, StructureKind, TargetId, TargetKind,
 };
 use crate::player::Player;
 use crate::team::Team;
@@ -43,17 +43,22 @@ const MINION_MARKER_RADIUS: f32 = 1.05;
 const NEUTRAL_MARKER_RADIUS: f32 = 1.1;
 const TOWER_MARKER_RADIUS: f32 = 2.0;
 const BASE_TOWER_MARKER_RADIUS: f32 = 3.75;
-const SKILL_BUTTON_SIZE: f32 = 80.0;
+const SKILL_BUTTON_SIZE: f32 = 72.0;
+const SKILL_SLOT_GAP: f32 = 8.0;
 const SKILL_BUTTON_MARGIN: f32 = 20.0;
 const SKILL_BUTTON_COLOR: Color = Color::srgba(0.12, 0.12, 0.12, 0.75);
 const SKILL_BUTTON_HOVER_COLOR: Color = Color::srgba(0.18, 0.18, 0.18, 0.85);
 const SKILL_BUTTON_PRESS_COLOR: Color = Color::srgba(0.28, 0.28, 0.28, 0.95);
+/// Slight gold tint when the server state allows spending a point on this slot (synced eligibility).
+const SKILL_BUTTON_AFFORDANCE_COLOR: Color = Color::srgba(0.18, 0.16, 0.08, 0.88);
 
 pub struct CombatPlugin;
 
 impl Plugin for CombatPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<TargetState>()
+            .init_resource::<HoveredSkillSlot>()
+            .init_resource::<LocalRangedCooldownUntil>()
             .add_systems(Startup, setup_combat_visual_assets)
             .add_systems(Startup, setup_combat_ui)
             .add_systems(
@@ -61,8 +66,13 @@ impl Plugin for CombatPlugin {
                 (
                     select_target_system,
                     clear_invalid_target_system,
+                    shift_skill_upgrade_hotkey_system,
                     cast_spell_system,
-                    skill_button_system,
+                    skill_hover_scan_system,
+                    skill_slot_button_appearance_system,
+                    skill_slot_press_system,
+                    update_skill_slot_labels_system,
+                    update_skill_tooltip_system,
                     update_target_marker_system,
                 )
                     .chain(),
@@ -129,8 +139,32 @@ struct CombatBars {
 #[derive(Component)]
 struct TargetMarker;
 
+#[derive(Component, Clone, Copy)]
+struct SkillSlotButton {
+    slot: u8,
+}
+
+#[derive(Component, Clone, Copy)]
+struct SkillSlotRankText {
+    slot: u8,
+}
+
+#[derive(Component, Clone, Copy)]
+struct SkillSlotCdText {
+    slot: u8,
+}
+
 #[derive(Component)]
-struct SkillButton;
+struct SkillTooltipRoot;
+
+#[derive(Component)]
+struct SkillTooltipBody;
+
+#[derive(Resource, Default)]
+struct HoveredSkillSlot(Option<u8>);
+
+#[derive(Resource, Default)]
+struct LocalRangedCooldownUntil(Option<f32>);
 
 #[derive(Component)]
 struct CombatBarRoot;
@@ -248,22 +282,385 @@ fn setup_combat_visual_assets(
 }
 
 fn setup_combat_ui(mut commands: Commands) {
-    commands.spawn((
-        Button,
-        Node {
-            position_type: PositionType::Absolute,
-            right: Val::Px(SKILL_BUTTON_MARGIN),
-            bottom: Val::Px(SKILL_BUTTON_MARGIN),
-            width: Val::Px(SKILL_BUTTON_SIZE),
-            height: Val::Px(SKILL_BUTTON_SIZE),
-            justify_content: JustifyContent::Center,
-            align_items: AlignItems::Center,
-            ..default()
-        },
-        BackgroundColor(SKILL_BUTTON_COLOR),
-        SkillButton,
-        Name::new("SkillButton"),
-    ));
+    commands
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                right: Val::Px(SKILL_BUTTON_MARGIN),
+                bottom: Val::Px(SKILL_BUTTON_MARGIN),
+                flex_direction: FlexDirection::Row,
+                column_gap: Val::Px(SKILL_SLOT_GAP),
+                ..default()
+            },
+            Name::new("SkillBar"),
+        ))
+        .with_children(|bar| {
+            for slot in 0_u8..4_u8 {
+                bar.spawn((
+                    Button,
+                    Node {
+                        width: Val::Px(SKILL_BUTTON_SIZE),
+                        height: Val::Px(SKILL_BUTTON_SIZE),
+                        flex_direction: FlexDirection::Column,
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        row_gap: Val::Px(2.0),
+                        ..default()
+                    },
+                    BackgroundColor(SKILL_BUTTON_COLOR),
+                    SkillSlotButton { slot },
+                    Name::new(format!("SkillSlot{slot}")),
+                ))
+                .with_children(|btn| {
+                    btn.spawn((
+                        Text::new(format!(
+                            "{}/{}",
+                            skills::STARTING_RANK,
+                            skills::MAX_SKILL_RANK
+                        )),
+                        TextFont {
+                            font_size: 16.0,
+                            ..default()
+                        },
+                        TextColor(Color::WHITE),
+                        SkillSlotRankText { slot },
+                    ));
+                    btn.spawn((
+                        Text::new(""),
+                        TextFont {
+                            font_size: 13.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgba(0.95, 0.82, 0.35, 1.0)),
+                        SkillSlotCdText { slot },
+                        Visibility::Hidden,
+                    ));
+                });
+            }
+        });
+
+    commands
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                left: Val::Px(SKILL_BUTTON_MARGIN),
+                bottom: Val::Px(SKILL_BUTTON_MARGIN + SKILL_BUTTON_SIZE + 18.0),
+                width: Val::Px(440.0),
+                padding: UiRect::all(Val::Px(12.0)),
+                flex_direction: FlexDirection::Column,
+                row_gap: Val::Px(4.0),
+                border_radius: BorderRadius::all(Val::Px(6.0)),
+                ..default()
+            },
+            BackgroundColor(Color::srgba(0.06, 0.07, 0.1, 0.94)),
+            Visibility::Hidden,
+            SkillTooltipRoot,
+            Name::new("SkillTooltip"),
+        ))
+        .with_children(|tip| {
+            tip.spawn((
+                Text::new(""),
+                TextFont {
+                    font_size: 17.0,
+                    ..default()
+                },
+                TextColor(Color::WHITE),
+                SkillTooltipBody,
+            ));
+        });
+}
+
+fn shift_skill_upgrade_hotkey_system(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    game_state: Option<Res<GameStateSnapshot>>,
+    mut command_writer: MessageWriter<NetworkCommand>,
+) {
+    if let Some(game_state) = game_state.as_ref() {
+        if !matches!(game_state.state, GameState::Running) {
+            return;
+        }
+    }
+    if !keyboard_input.pressed(KeyCode::ShiftLeft)
+        && !keyboard_input.pressed(KeyCode::ShiftRight)
+    {
+        return;
+    }
+    let slot = if keyboard_input.just_pressed(KeyCode::KeyQ) {
+        Some(0_u8)
+    } else if keyboard_input.just_pressed(KeyCode::KeyW) {
+        Some(1)
+    } else if keyboard_input.just_pressed(KeyCode::KeyE) {
+        Some(2)
+    } else if keyboard_input.just_pressed(KeyCode::KeyR) {
+        Some(3)
+    } else {
+        None
+    };
+    if let Some(slot) = slot {
+        command_writer.write(NetworkCommand::UpgradeSkill { slot });
+    }
+}
+
+fn skill_hover_scan_system(
+    buttons: Query<(&Interaction, &SkillSlotButton)>,
+    mut hover: ResMut<HoveredSkillSlot>,
+) {
+    hover.0 = None;
+    for (interaction, btn) in &buttons {
+        if *interaction == Interaction::Hovered || *interaction == Interaction::Pressed {
+            hover.0 = Some(btn.slot);
+            break;
+        }
+    }
+}
+
+fn skill_slot_button_appearance_system(
+    progression: Query<&PlayerProgression, With<Player>>,
+    mut buttons: Query<(&SkillSlotButton, &Interaction, &mut BackgroundColor), With<SkillSlotButton>>,
+) {
+    let Ok(progression) = progression.single() else {
+        return;
+    };
+    for (btn, interaction, mut color) in &mut buttons {
+        let slot = btn.slot as usize;
+        let afford = slot < skills::SLOT_COUNT
+            && skills::can_upgrade_slot(&progression.skill_ranks, slot, progression.skill_points);
+        match *interaction {
+            Interaction::Pressed => {
+                *color = SKILL_BUTTON_PRESS_COLOR.into();
+            }
+            Interaction::Hovered => {
+                *color = SKILL_BUTTON_HOVER_COLOR.into();
+            }
+            Interaction::None => {
+                *color = if afford {
+                    SKILL_BUTTON_AFFORDANCE_COLOR.into()
+                } else {
+                    SKILL_BUTTON_COLOR.into()
+                };
+            }
+        }
+    }
+}
+
+fn arm_local_slot0_cooldown(
+    cooldown: &mut LocalRangedCooldownUntil,
+    elapsed_secs: f32,
+    ranged_rank: u8,
+) {
+    cooldown.0 = Some(
+        elapsed_secs + skills::slot0_cooldown(ranged_rank).as_secs_f32(),
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn skill_slot_press_system(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    game_state: Option<Res<GameStateSnapshot>>,
+    mut interactions: Query<
+        (&Interaction, &SkillSlotButton),
+        (Changed<Interaction>, With<SkillSlotButton>),
+    >,
+    local_stats_query: Query<&CombatStats, With<Player>>,
+    progression: Query<&PlayerProgression, With<Player>>,
+    local_player: Query<(&Transform, &Team), With<Player>>,
+    player_candidates: Query<
+        (Entity, &Transform, &NetworkPlayerId, &CombatStats, &Team),
+        (With<RemotePlayer>, Without<Player>),
+    >,
+    minion_candidates: Query<
+        (Entity, &Transform, &NetworkMinionId, &CombatStats, &Team),
+        With<NetworkMinion>,
+    >,
+    neutral_candidates: Query<
+        (Entity, &Transform, &NetworkNeutralId, &CombatStats),
+        With<NetworkNeutral>,
+    >,
+    structure_candidates: Query<
+        (
+            Entity,
+            &Transform,
+            &NetworkStructureId,
+            &CombatStats,
+            &Team,
+            &StructureKind,
+        ),
+        With<NetworkStructure>,
+    >,
+    mut target_state: ResMut<TargetState>,
+    time: Res<Time>,
+    mut cooldown: ResMut<LocalRangedCooldownUntil>,
+    mut command_writer: MessageWriter<NetworkCommand>,
+    mut console: ResMut<DebugConsole>,
+) {
+    if let Some(game_state) = game_state.as_ref() {
+        if !matches!(game_state.state, GameState::Running) {
+            return;
+        }
+    }
+    let shift_held = keyboard_input.pressed(KeyCode::ShiftLeft)
+        || keyboard_input.pressed(KeyCode::ShiftRight);
+    let Ok(progression) = progression.single() else {
+        return;
+    };
+    for (interaction, btn) in interactions.iter_mut() {
+        if *interaction != Interaction::Pressed {
+            continue;
+        }
+        if shift_held {
+            command_writer.write(NetworkCommand::UpgradeSkill { slot: btn.slot });
+            continue;
+        }
+        if btn.slot != 0 {
+            continue;
+        }
+        let Ok(local_stats) = local_stats_query.single() else {
+            continue;
+        };
+        let _ = (
+            &local_player,
+            &player_candidates,
+            &minion_candidates,
+            &neutral_candidates,
+            &structure_candidates,
+        );
+        if let Some(target) = resolve_cast_target(&mut target_state) {
+            command_writer.write(NetworkCommand::Cast { slot: 0, target });
+            arm_local_slot0_cooldown(
+                &mut cooldown,
+                time.elapsed_secs(),
+                progression.skill_ranks[0],
+            );
+            let message = format!(
+                "Cast -> {} {} (mana {:.0})",
+                match target.kind {
+                    TargetKind::Player => "player",
+                    TargetKind::Minion => "minion",
+                    TargetKind::Structure => "structure",
+                    TargetKind::Neutral => "neutral",
+                },
+                target.id,
+                local_stats.mana
+            );
+            console.push_line(message.clone());
+            info!("{message}");
+        } else {
+            let message = "No target available. Use TAB or middle mouse click to select.";
+            console.push_line(message);
+            info!("{message}");
+        }
+    }
+}
+
+fn update_skill_slot_labels_system(
+    progression: Query<&PlayerProgression, With<Player>>,
+    mut rank_q: Query<(&mut Text, &SkillSlotRankText)>,
+    mut cd_q: Query<(&mut Text, &mut Visibility, &SkillSlotCdText)>,
+    time: Res<Time>,
+    mut cooldown: ResMut<LocalRangedCooldownUntil>,
+) {
+    let Ok(progression) = progression.single() else {
+        return;
+    };
+    if let Some(until) = cooldown.0 {
+        if time.elapsed_secs() >= until {
+            cooldown.0 = None;
+        }
+    }
+    for (mut text, tag) in &mut rank_q {
+        let slot = tag.slot as usize;
+        if slot < skills::SLOT_COUNT {
+            let r = progression.skill_ranks[slot];
+            text.0 = format!("{}/{}", r, skills::MAX_SKILL_RANK);
+        }
+    }
+    for (mut text, mut vis, tag) in &mut cd_q {
+        if tag.slot != 0 {
+            *vis = Visibility::Hidden;
+            continue;
+        }
+        if let Some(until) = cooldown.0 {
+            let left = (until - time.elapsed_secs()).max(0.0);
+            if left > 0.02 {
+                *vis = Visibility::Visible;
+                text.0 = format!("{left:.1}s");
+            } else {
+                *vis = Visibility::Hidden;
+                text.0.clear();
+            }
+        } else {
+            *vis = Visibility::Hidden;
+            text.0.clear();
+        }
+    }
+}
+
+fn update_skill_tooltip_system(
+    hover: Res<HoveredSkillSlot>,
+    progression: Query<&PlayerProgression, With<Player>>,
+    mut tooltip_root: Query<&mut Visibility, With<SkillTooltipRoot>>,
+    mut tooltip_text: Query<&mut Text, With<SkillTooltipBody>>,
+) {
+    let Ok(progression) = progression.single() else {
+        return;
+    };
+    let Some(slot) = hover.0.map(|s| s as usize) else {
+        for mut vis in &mut tooltip_root {
+            *vis = Visibility::Hidden;
+        }
+        return;
+    };
+    let Some(meta) = skills::skill_meta(slot) else {
+        return;
+    };
+    let ranks = progression.skill_ranks;
+    let mana_line = if slot == 0 {
+        format!(
+            "Mana cost: {:.0}",
+            skills::slot0_mana_cost(ranks[0])
+        )
+    } else {
+        "Mana cost: — (passive)".to_string()
+    };
+    let cd_line = if let Some(ms) = skills::cooldown_label_ms(slot, ranks[0]) {
+        format!("Cooldown: {:.2}s", ms as f32 / 1000.0)
+    } else {
+        "Cooldown: — (passive)".to_string()
+    };
+    let current_val = skills::primary_value_for_slot(slot, &ranks);
+    let current_line = format!(
+        "Current: {}",
+        skills::primary_value_tooltip_current(slot, current_val)
+    );
+
+    let upgradeable = skills::can_upgrade_slot(&ranks, slot, progression.skill_points);
+    let next_line = if upgradeable {
+        skills::next_rank_primary_value(slot, &ranks).map_or_else(
+            || String::new(),
+            |nv| {
+                format!(
+                    "Next rank: {}\nHold Shift and click the slot or press Shift+Q/W/E/R to upgrade.",
+                    skills::primary_value_tooltip_next_rank(slot, nv)
+                )
+            },
+        )
+    } else if ranks[slot] >= skills::MAX_SKILL_RANK {
+        "Max rank reached.".to_string()
+    } else {
+        "No skill points available.".to_string()
+    };
+
+    let body = format!(
+        "{}\n{}\n\n{mana_line}\n{cd_line}\n{current_line}\n{next_line}",
+        meta.name, meta.description,
+    );
+
+    for mut vis in &mut tooltip_root {
+        *vis = Visibility::Visible;
+    }
+    for mut text in &mut tooltip_text {
+        text.0 = body.clone();
+    }
 }
 
 fn select_target_system(
@@ -389,6 +786,9 @@ fn cast_spell_system(
     keyboard_input: Res<ButtonInput<KeyCode>>,
     game_state: Option<Res<GameStateSnapshot>>,
     local_stats_query: Query<&CombatStats, With<Player>>,
+    progression: Query<&PlayerProgression, With<Player>>,
+    time: Res<Time>,
+    mut cooldown: ResMut<LocalRangedCooldownUntil>,
     local_player: Query<(&Transform, &Team), With<Player>>,
     player_candidates: Query<
         (Entity, &Transform, &NetworkPlayerId, &CombatStats, &Team),
@@ -422,11 +822,19 @@ fn cast_spell_system(
             return;
         }
     }
+    if keyboard_input.pressed(KeyCode::ShiftLeft)
+        || keyboard_input.pressed(KeyCode::ShiftRight)
+    {
+        return;
+    }
     if !keyboard_input.just_pressed(KeyCode::KeyQ) {
         return;
     }
 
     let Ok(local_stats) = local_stats_query.single() else {
+        return;
+    };
+    let Ok(progression) = progression.single() else {
         return;
     };
     let _ = (
@@ -438,7 +846,12 @@ fn cast_spell_system(
     );
     let target = resolve_cast_target(&mut target_state);
     if let Some(target) = target {
-        command_writer.write(NetworkCommand::Cast { target });
+        command_writer.write(NetworkCommand::Cast { slot: 0, target });
+        arm_local_slot0_cooldown(
+            &mut cooldown,
+            time.elapsed_secs(),
+            progression.skill_ranks[0],
+        );
         let message = format!(
             "Cast -> {} {} (mana {:.0})",
             match target.kind {
@@ -456,91 +869,6 @@ fn cast_spell_system(
         let message = "No target available. Use TAB or middle mouse click to select.";
         console.push_line(message);
         info!("{message}");
-    }
-}
-
-fn skill_button_system(
-    mut interactions: Query<
-        (&Interaction, &mut BackgroundColor),
-        (Changed<Interaction>, With<SkillButton>),
-    >,
-    game_state: Option<Res<GameStateSnapshot>>,
-    local_stats_query: Query<&CombatStats, With<Player>>,
-    local_player: Query<(&Transform, &Team), With<Player>>,
-    player_candidates: Query<
-        (Entity, &Transform, &NetworkPlayerId, &CombatStats, &Team),
-        (With<RemotePlayer>, Without<Player>),
-    >,
-    minion_candidates: Query<
-        (Entity, &Transform, &NetworkMinionId, &CombatStats, &Team),
-        With<NetworkMinion>,
-    >,
-    neutral_candidates: Query<
-        (Entity, &Transform, &NetworkNeutralId, &CombatStats),
-        With<NetworkNeutral>,
-    >,
-    structure_candidates: Query<
-        (
-            Entity,
-            &Transform,
-            &NetworkStructureId,
-            &CombatStats,
-            &Team,
-            &StructureKind,
-        ),
-        With<NetworkStructure>,
-    >,
-    mut target_state: ResMut<TargetState>,
-    mut command_writer: MessageWriter<NetworkCommand>,
-    mut console: ResMut<DebugConsole>,
-) {
-    if let Some(game_state) = game_state.as_ref() {
-        if !matches!(game_state.state, GameState::Running) {
-            return;
-        }
-    }
-    for (interaction, mut color) in interactions.iter_mut() {
-        match *interaction {
-            Interaction::Pressed => {
-                *color = SKILL_BUTTON_PRESS_COLOR.into();
-                let Ok(local_stats) = local_stats_query.single() else {
-                    continue;
-                };
-                let _ = (
-                    &local_player,
-                    &player_candidates,
-                    &minion_candidates,
-                    &neutral_candidates,
-                    &structure_candidates,
-                );
-                if let Some(target) = resolve_cast_target(&mut target_state) {
-                    command_writer.write(NetworkCommand::Cast { target });
-                    let message = format!(
-                        "Cast -> {} {} (mana {:.0})",
-                        match target.kind {
-                            TargetKind::Player => "player",
-                            TargetKind::Minion => "minion",
-                            TargetKind::Structure => "structure",
-                            TargetKind::Neutral => "neutral",
-                        },
-                        target.id,
-                        local_stats.mana
-                    );
-                    console.push_line(message.clone());
-                    info!("{message}");
-                } else {
-                    let message = "No target available. Use TAB or middle mouse click to select.";
-                    console.push_line(message);
-                    info!("{message}");
-                }
-            }
-            Interaction::Hovered => {
-                *color = SKILL_BUTTON_HOVER_COLOR.into();
-            }
-            Interaction::None => {
-                *color = SKILL_BUTTON_COLOR.into();
-            }
-        }
     }
 }
 

--- a/client/src/net.rs
+++ b/client/src/net.rs
@@ -70,7 +70,8 @@ impl Plugin for NetworkingPlugin {
 
 #[derive(Message, Clone, Copy, Debug)]
 pub enum NetworkCommand {
-    Cast { target: TargetId },
+    Cast { slot: u8, target: TargetId },
+    UpgradeSkill { slot: u8 },
     Join { team: Team, character: CharacterChoice },
     #[allow(dead_code)]
     RequestRematch,
@@ -86,7 +87,12 @@ enum ClientPacket {
         yaw: f32,
     },
     Cast {
+        #[serde(default)]
+        slot: u8,
         target: TargetId,
+    },
+    UpgradeSkill {
+        slot: u8,
     },
     Join {
         team: Team,
@@ -139,8 +145,14 @@ struct PlayerState {
     next_level_xp: u32,
     #[serde(default)]
     skill_points: u32,
+    #[serde(default = "default_skill_ranks")]
+    skill_ranks: [u8; skills::SLOT_COUNT],
     #[serde(default = "default_character_choice")]
     character: CharacterChoice,
+}
+
+fn default_skill_ranks() -> [u8; skills::SLOT_COUNT] {
+    [skills::STARTING_RANK; skills::SLOT_COUNT]
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -310,12 +322,25 @@ pub struct NetworkPlayerId(pub u64);
 #[derive(Component, Clone, Copy, Debug)]
 pub struct NetworkCharacterChoice(pub CharacterChoice);
 
-#[derive(Component, Clone, Copy, Debug, Default)]
+#[derive(Component, Clone, Copy, Debug)]
 pub struct PlayerProgression {
     pub level: u32,
     pub xp: u32,
     pub next_level_xp: u32,
     pub skill_points: u32,
+    pub skill_ranks: [u8; skills::SLOT_COUNT],
+}
+
+impl Default for PlayerProgression {
+    fn default() -> Self {
+        Self {
+            level: DEFAULT_PLAYER_LEVEL,
+            xp: 0,
+            next_level_xp: DEFAULT_NEXT_LEVEL_XP,
+            skill_points: 0,
+            skill_ranks: [skills::STARTING_RANK; skills::SLOT_COUNT],
+        }
+    }
 }
 
 #[derive(Component)]
@@ -590,10 +615,16 @@ fn send_network_commands(
 
     for command in command_events.read() {
         match command {
-            NetworkCommand::Cast { target } => {
+            NetworkCommand::Cast { slot, target } => {
+                let _ = channels.outgoing.send(ClientPacket::Cast {
+                    slot: *slot,
+                    target: *target,
+                });
+            }
+            NetworkCommand::UpgradeSkill { slot } => {
                 let _ = channels
                     .outgoing
-                    .send(ClientPacket::Cast { target: *target });
+                    .send(ClientPacket::UpgradeSkill { slot: *slot });
             }
             NetworkCommand::Join { team, character } => {
                 let _ = channels.outgoing.send(ClientPacket::Join {
@@ -1227,6 +1258,7 @@ fn player_state_to_progression(player: &PlayerState) -> PlayerProgression {
         xp: player.xp,
         next_level_xp: player.next_level_xp,
         skill_points: player.skill_points,
+        skill_ranks: player.skill_ranks,
     }
 }
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -10,7 +10,10 @@ Canonical version: `0.2.0`
 - Core combat loop with projectiles, structures, minions, death, respawn, mana regeneration, and base-destruction win condition.
 - Map layout with three lanes and simple jungle blocks.
 - Player progression with level-based XP thresholds, HP/mana scaling on level-up, and tracked skill points.
-- In-game local HUD display for level and XP progression.
+- In-game local HUD display for level, XP progression, and available skill points.
+- Four-slot skill bar (Q/W/E/R): rank vs max rank, local cooldown readout for the active shot, and a gold-tinted idle state when the server snapshot indicates an upgrade is allowed (skill point available and below max rank).
+- **Skill upgrades (authoritative):** hold **Shift** and click a slot, or press **Shift+Q / Shift+W / Shift+E / Shift+R** to send an upgrade intent. The server validates points, rank cap, and slot; the next snapshot updates ranks and gameplay numbers (damage, mana cost, cooldown, passives) immediately.
+- **Tooltips:** hover a skill slot for name, description, mana cost, cooldown (active vs passive), current primary value, and next-rank preview when upgradeable. Tooltip text and numbers come from the shared `skills` crate so they stay aligned with server simulation.
 
 ## Multiplayer Session Reliability
 
@@ -27,4 +30,4 @@ Canonical version: `0.2.0`
 - Full reconnect slot reclaim across disconnects and NAT changes.
 - Match phase, restart, and rematch flow.
 - Jungle camps and neutral AI.
-- Full skill system, tooltip UX, and release-readiness validation.
+- Release-readiness validation for the full combat/skill loop in production builds.

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,3 +6,4 @@ edition.workspace = true
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
+skills = { path = "../skills" }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -16,11 +16,7 @@ const MAX_PACKET_SIZE: usize = 8 * 1024;
 const MAX_HP: f32 = 100.0;
 const MAX_MANA: f32 = 100.0;
 const MANA_REGEN_PER_SECOND: f32 = 8.0;
-const SPELL_MANA_COST: f32 = 20.0;
-const SPELL_COOLDOWN: Duration = Duration::from_millis(350);
-
 const PROJECTILE_SPEED: f32 = 19.0;
-const PROJECTILE_DAMAGE: f32 = 20.0;
 const PROJECTILE_RADIUS: f32 = 0.22;
 const PROJECTILE_LIFETIME: Duration = Duration::from_secs(3);
 const PLAYER_HIT_RADIUS: f32 = 0.62;
@@ -87,7 +83,12 @@ enum ClientPacket {
         yaw: f32,
     },
     Cast {
+        #[serde(default)]
+        slot: u8,
         target: TargetId,
+    },
+    UpgradeSkill {
+        slot: u8,
     },
     Join {
         team: Team,
@@ -158,8 +159,27 @@ struct PlayerState {
     level: u32,
     next_level_xp: u32,
     skill_points: u32,
+    #[serde(default = "default_skill_ranks")]
+    skill_ranks: [u8; skills::SLOT_COUNT],
     #[serde(default = "default_character_choice")]
     character: CharacterChoice,
+}
+
+fn default_skill_ranks() -> [u8; skills::SLOT_COUNT] {
+    [skills::STARTING_RANK; skills::SLOT_COUNT]
+}
+
+fn try_upgrade_skill(state: &mut PlayerState, slot: u8) -> bool {
+    let slot_usize = slot as usize;
+    if slot_usize >= skills::SLOT_COUNT {
+        return false;
+    }
+    if !skills::can_upgrade_slot(&state.skill_ranks, slot_usize, state.skill_points) {
+        return false;
+    }
+    state.skill_points -= 1;
+    state.skill_ranks[slot_usize] = state.skill_ranks[slot_usize].saturating_add(1);
+    true
 }
 
 fn xp_threshold_for_level(level: u32) -> u32 {
@@ -591,7 +611,7 @@ fn main() -> io::Result<()> {
                                 player.state.yaw = yaw;
                             }
                         }
-                        ClientPacket::Cast { target } => {
+                        ClientPacket::Cast { slot, target } => {
                             handle_cast_request(
                                 &mut players,
                                 &mut projectiles,
@@ -599,11 +619,19 @@ fn main() -> io::Result<()> {
                                 &mut structures,
                                 &mut neutrals,
                                 addr,
+                                slot,
                                 target,
                                 &mut next_projectile_id,
                                 &game_state,
                                 now,
                             );
+                        }
+                        ClientPacket::UpgradeSkill { slot } => {
+                            if matches!(game_state, GameState::Running)
+                                && let Some(player) = players.get_mut(&addr)
+                            {
+                                let _applied = try_upgrade_skill(&mut player.state, slot);
+                            }
                         }
                         ClientPacket::Join { team, character } => {
                             if let Some(player) = players.get_mut(&addr) {
@@ -647,6 +675,7 @@ fn main() -> io::Result<()> {
         last_simulation_at = now;
 
         regenerate_mana(&mut players, dt);
+        apply_vitality_regen(&mut players, dt);
         spawn_minion_waves_if_due(
             &map_layout,
             &mut minions,
@@ -838,6 +867,7 @@ fn ensure_player_connected(
                 level: STARTING_LEVEL,
                 next_level_xp: xp_threshold_for_level(STARTING_LEVEL),
                 skill_points: 0,
+                skill_ranks: default_skill_ranks(),
                 character: default_character_choice(),
             },
             last_seen: now,
@@ -855,8 +885,20 @@ fn regenerate_mana(players: &mut HashMap<SocketAddr, ConnectedPlayer>, dt: f32) 
         if player.state.max_mana <= 0.0 {
             player.state.max_mana = MAX_MANA;
         }
-        player.state.mana =
-            (player.state.mana + MANA_REGEN_PER_SECOND * dt).clamp(0.0, player.state.max_mana);
+        let focus_bonus = skills::focus_mana_regen_bonus(player.state.skill_ranks[2]);
+        player.state.mana = (player.state.mana
+            + (MANA_REGEN_PER_SECOND + focus_bonus) * dt)
+            .clamp(0.0, player.state.max_mana);
+    }
+}
+
+fn apply_vitality_regen(players: &mut HashMap<SocketAddr, ConnectedPlayer>, dt: f32) {
+    for player in players.values_mut() {
+        if player.state.hp <= 0.0 || player.state.hp >= player.state.max_hp {
+            continue;
+        }
+        let regen = skills::vitality_hp_per_second(player.state.skill_ranks[1]);
+        player.state.hp = (player.state.hp + regen * dt).min(player.state.max_hp);
     }
 }
 
@@ -886,6 +928,7 @@ fn handle_join_request(
     player.state.level = STARTING_LEVEL;
     player.state.next_level_xp = xp_threshold_for_level(STARTING_LEVEL);
     player.state.skill_points = 0;
+    player.state.skill_ranks = default_skill_ranks();
     player.last_cast_at = None;
     player.respawn_at = None;
 }
@@ -898,6 +941,7 @@ fn handle_cast_request(
     structures: &mut HashMap<u64, Structure>,
     neutrals: &mut HashMap<u64, Neutral>,
     caster_addr: SocketAddr,
+    slot: u8,
     target: TargetId,
     next_projectile_id: &mut u64,
     game_state: &GameState,
@@ -906,18 +950,23 @@ fn handle_cast_request(
     if !matches!(game_state, GameState::Running) {
         return;
     }
+    if slot != 0 {
+        return;
+    }
     let Some(caster) = players.get(&caster_addr) else {
         return;
     };
     if caster.state.hp <= 0.0 {
         return;
     }
-    if caster.state.mana < SPELL_MANA_COST {
+    let mana_cost = skills::slot0_mana_cost(caster.state.skill_ranks[0]);
+    let cooldown = skills::slot0_cooldown(caster.state.skill_ranks[0]);
+    if caster.state.mana < mana_cost {
         return;
     }
     if caster
         .last_cast_at
-        .is_some_and(|last_cast| now.duration_since(last_cast) < SPELL_COOLDOWN)
+        .is_some_and(|last_cast| now.duration_since(last_cast) < cooldown)
     {
         return;
     }
@@ -998,7 +1047,12 @@ fn handle_cast_request(
     let Some(caster_mut) = players.get_mut(&caster_addr) else {
         return;
     };
-    caster_mut.state.mana -= SPELL_MANA_COST;
+    let projectile_speed = skills::effective_projectile_speed(
+        caster_mut.state.skill_ranks[0],
+        caster_mut.state.skill_ranks[3],
+    );
+    let projectile_damage = skills::slot0_damage(caster_mut.state.skill_ranks[0]);
+    caster_mut.state.mana -= mana_cost;
     caster_mut.last_cast_at = Some(now);
 
     let projectile_id = *next_projectile_id;
@@ -1017,13 +1071,13 @@ fn handle_cast_request(
             },
             target,
             velocity: Vec3f::new(
-                direction.x * PROJECTILE_SPEED,
-                direction.y * PROJECTILE_SPEED,
-                direction.z * PROJECTILE_SPEED,
+                direction.x * projectile_speed,
+                direction.y * projectile_speed,
+                direction.z * projectile_speed,
             ),
             homing: true,
             guaranteed_hit: true,
-            damage: PROJECTILE_DAMAGE,
+            damage: projectile_damage,
             radius: PROJECTILE_RADIUS,
             expires_at: now + PROJECTILE_LIFETIME,
         },
@@ -2338,13 +2392,124 @@ mod tests {
         player.state.max_mana = MAX_MANA;
 
         regenerate_mana(&mut players, 2.5);
-        let expected = 10.0 + MANA_REGEN_PER_SECOND * 2.5;
+        let bonus = skills::focus_mana_regen_bonus(
+            players.get(&addr).unwrap().state.skill_ranks[2],
+        );
+        let expected = 10.0 + (MANA_REGEN_PER_SECOND + bonus) * 2.5;
         let current = players.get(&addr).unwrap().state.mana;
         assert!((current - expected).abs() < EPSILON);
 
         regenerate_mana(&mut players, 100.0);
         let clamped = players.get(&addr).unwrap().state.mana;
         assert!((clamped - MAX_MANA).abs() < EPSILON);
+    }
+
+    #[test]
+    fn upgrade_skill_spends_point_and_increments_rank() {
+        let layout = build_map_layout();
+        let mut players = HashMap::new();
+        let mut next_player_id = 1;
+        let addr: SocketAddr = "127.0.0.1:34571".parse().unwrap();
+        let now = Instant::now();
+
+        ensure_player_connected(&mut players, &layout, addr, &mut next_player_id, now);
+        let state = &mut players.get_mut(&addr).unwrap().state;
+        state.skill_points = 1;
+        assert!(try_upgrade_skill(state, 0));
+        assert_eq!(state.skill_points, 0);
+        assert_eq!(state.skill_ranks[0], skills::STARTING_RANK + 1);
+    }
+
+    #[test]
+    fn upgrade_skill_rejects_without_points_or_invalid_slot() {
+        let layout = build_map_layout();
+        let mut players = HashMap::new();
+        let mut next_player_id = 1;
+        let addr: SocketAddr = "127.0.0.1:34572".parse().unwrap();
+        let now = Instant::now();
+
+        ensure_player_connected(&mut players, &layout, addr, &mut next_player_id, now);
+        let state = &mut players.get_mut(&addr).unwrap().state;
+        state.skill_points = 0;
+        let ranks_before = state.skill_ranks;
+        assert!(!try_upgrade_skill(state, 0));
+        assert_eq!(state.skill_ranks, ranks_before);
+        assert!(!try_upgrade_skill(state, 9));
+    }
+
+    #[test]
+    fn apply_level_up_grants_one_skill_point() {
+        let layout = build_map_layout();
+        let mut players = HashMap::new();
+        let mut next_player_id = 1;
+        let addr: SocketAddr = "127.0.0.1:34573".parse().unwrap();
+        let now = Instant::now();
+
+        ensure_player_connected(&mut players, &layout, addr, &mut next_player_id, now);
+        let state = &mut players.get_mut(&addr).unwrap().state;
+        let before = state.skill_points;
+        apply_level_up(state);
+        assert_eq!(state.skill_points, before.saturating_add(1));
+    }
+
+    #[test]
+    fn grant_xp_over_threshold_levels_and_awards_skill_point() {
+        let layout = build_map_layout();
+        let mut players = HashMap::new();
+        let mut next_player_id = 1;
+        let addr: SocketAddr = "127.0.0.1:34574".parse().unwrap();
+        let now = Instant::now();
+
+        ensure_player_connected(&mut players, &layout, addr, &mut next_player_id, now);
+        let state = &mut players.get_mut(&addr).unwrap().state;
+        assert_eq!(state.skill_points, 0);
+        let before_level = state.level;
+        state.xp = state.next_level_xp.saturating_sub(1);
+        grant_player_xp(state, 1);
+        assert_eq!(state.level, before_level + 1);
+        assert_eq!(state.skill_points, 1);
+    }
+
+    #[test]
+    fn upgrade_skill_rejects_at_max_rank_even_with_points() {
+        let layout = build_map_layout();
+        let mut players = HashMap::new();
+        let mut next_player_id = 1;
+        let addr: SocketAddr = "127.0.0.1:34575".parse().unwrap();
+        let now = Instant::now();
+
+        ensure_player_connected(&mut players, &layout, addr, &mut next_player_id, now);
+        let state = &mut players.get_mut(&addr).unwrap().state;
+        state.skill_points = 3;
+        state.skill_ranks[0] = skills::MAX_SKILL_RANK;
+        let ranks_before = state.skill_ranks;
+        let points_before = state.skill_points;
+        assert!(!try_upgrade_skill(state, 0));
+        assert_eq!(state.skill_ranks, ranks_before);
+        assert_eq!(state.skill_points, points_before);
+    }
+
+    #[test]
+    fn upgrade_slot0_updates_authoritative_cast_mana_and_cooldown() {
+        let layout = build_map_layout();
+        let mut players = HashMap::new();
+        let mut next_player_id = 1;
+        let addr: SocketAddr = "127.0.0.1:34576".parse().unwrap();
+        let now = Instant::now();
+
+        ensure_player_connected(&mut players, &layout, addr, &mut next_player_id, now);
+        let state = &mut players.get_mut(&addr).unwrap().state;
+        state.skill_points = 1;
+        let rank_before = state.skill_ranks[0];
+        let mana_before = skills::slot0_mana_cost(rank_before);
+        let cd_before = skills::slot0_cooldown(rank_before);
+        assert!(try_upgrade_skill(state, 0));
+        let rank_after = state.skill_ranks[0];
+        assert_eq!(rank_after, rank_before + 1);
+        let mana_after = skills::slot0_mana_cost(rank_after);
+        let cd_after = skills::slot0_cooldown(rank_after);
+        assert!(mana_after <= mana_before);
+        assert!(cd_after <= cd_before);
     }
 
     #[test]

--- a/skills/Cargo.toml
+++ b/skills/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "skills"
+version.workspace = true
+edition.workspace = true
+description = "Shared hero skill definitions (costs, cooldowns, scaling) for client and server"
+
+[dependencies]

--- a/skills/src/lib.rs
+++ b/skills/src/lib.rs
@@ -1,0 +1,245 @@
+//! Data-driven skill parameters shared by the game client and server.
+//! All gameplay numbers for tooltips and simulation must be derived from this module.
+
+use std::time::Duration;
+
+/// Number of ability slots in the HUD (Q/W/E/R style).
+pub const SLOT_COUNT: usize = 4;
+
+/// Every skill starts at this rank; points raise it up to [`MAX_SKILL_RANK`].
+pub const STARTING_RANK: u8 = 1;
+
+/// Maximum rank per skill (inclusive).
+pub const MAX_SKILL_RANK: u8 = 5;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SkillMeta {
+    pub slot: usize,
+    pub name: &'static str,
+    pub description: &'static str,
+}
+
+/// Static presentation + semantics for one slot index (0..4).
+pub fn skill_meta(slot: usize) -> Option<SkillMeta> {
+    match slot {
+        0 => Some(SkillMeta {
+            slot: 0,
+            name: "Ranged Shot",
+            description: "Fires a homing projectile at the selected enemy.",
+        }),
+        1 => Some(SkillMeta {
+            slot: 1,
+            name: "Vitality",
+            description: "Passive: restores health over time while alive.",
+        }),
+        2 => Some(SkillMeta {
+            slot: 2,
+            name: "Focus",
+            description: "Passive: increases mana regeneration.",
+        }),
+        3 => Some(SkillMeta {
+            slot: 3,
+            name: "Velocity",
+            description: "Passive: increases Ranged Shot projectile speed.",
+        }),
+        _ => None,
+    }
+}
+
+fn clamp_rank(rank: u8) -> u8 {
+    rank.clamp(STARTING_RANK, MAX_SKILL_RANK)
+}
+
+// --- Slot 0: Ranged Shot (active projectile) ---
+
+const SLOT0_BASE_MANA: f32 = 20.0;
+const SLOT0_MANA_PER_RANK: f32 = -1.5;
+const SLOT0_BASE_COOLDOWN_MS: u64 = 350;
+const SLOT0_COOLDOWN_DELTA_MS_PER_RANK: i64 = -25;
+const SLOT0_BASE_DAMAGE: f32 = 20.0;
+const SLOT0_DAMAGE_PER_RANK: f32 = 4.0;
+const SLOT0_BASE_PROJECTILE_SPEED: f32 = 19.0;
+const SLOT0_SPEED_PER_RANK: f32 = 0.6;
+
+/// Mana cost for Ranged Shot at the given rank.
+pub fn slot0_mana_cost(rank: u8) -> f32 {
+    let r = clamp_rank(rank);
+    let steps = u32::from(r - STARTING_RANK);
+    (SLOT0_BASE_MANA + SLOT0_MANA_PER_RANK * steps as f32).max(6.0)
+}
+
+/// Cooldown after casting Ranged Shot.
+pub fn slot0_cooldown(rank: u8) -> Duration {
+    let r = clamp_rank(rank);
+    let steps = i64::from(r - STARTING_RANK);
+    let ms = (SLOT0_BASE_COOLDOWN_MS as i64 + SLOT0_COOLDOWN_DELTA_MS_PER_RANK * steps).max(200);
+    Duration::from_millis(ms as u64)
+}
+
+/// Projectile impact damage for Ranged Shot.
+pub fn slot0_damage(rank: u8) -> f32 {
+    let r = clamp_rank(rank);
+    let steps = u32::from(r - STARTING_RANK);
+    SLOT0_BASE_DAMAGE + SLOT0_DAMAGE_PER_RANK * steps as f32
+}
+
+/// Base projectile linear speed before Velocity passive.
+pub fn slot0_projectile_speed(rank: u8) -> f32 {
+    let r = clamp_rank(rank);
+    let steps = u32::from(r - STARTING_RANK);
+    SLOT0_BASE_PROJECTILE_SPEED + SLOT0_SPEED_PER_RANK * steps as f32
+}
+
+// --- Slot 1: Vitality (HP regen / sec) ---
+
+const VITALITY_BASE: f32 = 0.35;
+const VITALITY_PER_RANK: f32 = 0.22;
+
+pub fn vitality_hp_per_second(rank: u8) -> f32 {
+    let r = clamp_rank(rank);
+    let steps = u32::from(r - STARTING_RANK);
+    VITALITY_BASE + VITALITY_PER_RANK * steps as f32
+}
+
+// --- Slot 2: Focus (additive mana regen / sec) ---
+
+const FOCUS_BASE: f32 = 0.35;
+const FOCUS_PER_RANK: f32 = 0.55;
+
+pub fn focus_mana_regen_bonus(rank: u8) -> f32 {
+    let r = clamp_rank(rank);
+    let steps = u32::from(r - STARTING_RANK);
+    FOCUS_BASE + FOCUS_PER_RANK * steps as f32
+}
+
+// --- Slot 3: Velocity (multiplier on projectile speed) ---
+
+pub fn velocity_speed_multiplier(rank: u8) -> f32 {
+    let r = clamp_rank(rank);
+    let steps = u32::from(r - STARTING_RANK);
+    1.0 + 0.05 * steps as f32
+}
+
+/// Effective projectile speed with both Ranged Shot rank and Velocity rank.
+pub fn effective_projectile_speed(ranged_rank: u8, velocity_rank: u8) -> f32 {
+    slot0_projectile_speed(ranged_rank) * velocity_speed_multiplier(velocity_rank)
+}
+
+/// Primary "value" line for tooltip: combat-relevant number per slot.
+pub fn primary_value_for_slot(slot: usize, ranks: &[u8; SLOT_COUNT]) -> f32 {
+    match slot {
+        0 => slot0_damage(ranks[0]),
+        1 => vitality_hp_per_second(ranks[1]),
+        2 => focus_mana_regen_bonus(ranks[2]),
+        3 => velocity_speed_multiplier(ranks[3]),
+        _ => 0.0,
+    }
+}
+
+/// Next rank primary value, or `None` if already at max.
+pub fn next_rank_primary_value(slot: usize, ranks: &[u8; SLOT_COUNT]) -> Option<f32> {
+    let r = ranks.get(slot).copied()?;
+    if r >= MAX_SKILL_RANK {
+        return None;
+    }
+    let mut next = *ranks;
+    next[slot] = r + 1;
+    Some(primary_value_for_slot(slot, &next))
+}
+
+/// Whether the player can spend a point on this slot (server-side rules mirrored for UI).
+pub fn can_upgrade_slot(ranks: &[u8; SLOT_COUNT], slot: usize, skill_points: u32) -> bool {
+    skill_points > 0 && slot < SLOT_COUNT && ranks[slot] < MAX_SKILL_RANK
+}
+
+/// Cooldown label for UI: active slot 0 uses real cooldown; passives show em dash.
+pub fn cooldown_label_ms(slot: usize, ranged_rank: u8) -> Option<u64> {
+    if slot == 0 {
+        Some(slot0_cooldown(ranged_rank).as_millis() as u64)
+    } else {
+        None
+    }
+}
+
+/// Full tooltip line for the primary stat at the player's current rank (same semantics as simulation).
+pub fn primary_value_tooltip_current(slot: usize, value: f32) -> String {
+    match slot {
+        0 => format!("{value:.0} projectile damage"),
+        1 => format!("{value:.2} HP restored per second"),
+        2 => format!("{value:.2} bonus mana regen per second"),
+        3 => format!("×{value:.2} projectile speed multiplier"),
+        _ => format!("{value:.2}"),
+    }
+}
+
+/// Compact primary-stat fragment for the "next rank" preview line in tooltips.
+pub fn primary_value_tooltip_next_rank(slot: usize, value: f32) -> String {
+    match slot {
+        0 => format!("{value:.0} damage"),
+        1 => format!("{value:.2} HP/s"),
+        2 => format!("{value:.2} mana/s"),
+        3 => format!("×{value:.2} speed"),
+        _ => format!("{value:.2}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upgrade_only_when_points_and_below_cap() {
+        let mut ranks = [1_u8; SLOT_COUNT];
+        assert!(can_upgrade_slot(&ranks, 0, 1));
+        ranks[0] = MAX_SKILL_RANK;
+        assert!(!can_upgrade_slot(&ranks, 0, 1));
+        assert!(!can_upgrade_slot(&ranks, 0, 0));
+    }
+
+    #[test]
+    fn slot0_scales_with_rank() {
+        let d1 = slot0_damage(STARTING_RANK);
+        let d5 = slot0_damage(MAX_SKILL_RANK);
+        assert!(d5 > d1);
+        assert!(slot0_mana_cost(MAX_SKILL_RANK) < slot0_mana_cost(STARTING_RANK));
+        assert!(slot0_cooldown(MAX_SKILL_RANK) < slot0_cooldown(STARTING_RANK));
+    }
+
+    #[test]
+    fn next_rank_preview_is_some_until_max() {
+        let ranks = [1, 2, 3, 4];
+        assert!(next_rank_primary_value(0, &ranks).is_some());
+        let maxed = [MAX_SKILL_RANK; SLOT_COUNT];
+        assert!(next_rank_primary_value(0, &maxed).is_none());
+    }
+
+    #[test]
+    fn next_rank_primary_matches_incremented_rank_vector() {
+        let ranks = [2_u8, 3, 1, 4];
+        for slot in 0..SLOT_COUNT {
+            if ranks[slot] >= MAX_SKILL_RANK {
+                continue;
+            }
+            let preview = next_rank_primary_value(slot, &ranks).expect("below max");
+            let mut bumped = ranks;
+            bumped[slot] = ranks[slot] + 1;
+            let direct = primary_value_for_slot(slot, &bumped);
+            assert!(
+                (preview - direct).abs() < 1e-4,
+                "slot {slot}: preview {preview} vs direct {direct}"
+            );
+        }
+    }
+
+    #[test]
+    fn tooltip_current_line_matches_slot0_damage_text() {
+        let ranks = [3_u8, 1, 1, 1];
+        let v = primary_value_for_slot(0, &ranks);
+        assert_eq!(v, slot0_damage(ranks[0]));
+        let line = primary_value_tooltip_current(0, v);
+        assert_eq!(
+            line,
+            format!("{:.0} projectile damage", slot0_damage(ranks[0]))
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Complete upgrade gating and data-driven tooltip values aligned with authoritative skill math.
- Keep the branch scoped to TASK-11 acceptance criteria and verifier outcomes.
- Preserve isolated worktree history for easier review.

## Test plan
- [x] Run branch build/test checks captured in task evidence.
- [x] Run a fresh verifier pass for TASK-11.
- [ ] Optional manual gameplay smoke before merge.

Made with [Cursor](https://cursor.com)