### PR TITLE
TASK-13: finalize onboarding and core HUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The canonical repository version lives in `Cargo.toml` under `[workspace.package
 ## [Unreleased]
 
 ### Added
+- **TASK-13 (client):** Match HUD column (level, XP, skill points, upgrade key hint, HP/mana, target summary, objective line, F1 reminder); bottom skill bar with four labeled slots (`Q`–`R`) wired to the same cast action until the server exposes distinct skills; centralized key labels in `input_bindings`; F1 help overlay with control and objective copy; clearer victory/defeat next-step text; help panel only renders during `Running` so lobby/victory overlays stay readable on reconnect/snapshot transitions; bracketed skill slot line and display strings derived from `SKILL_SLOT_KEY_LABELS`; unit tests for binding/display consistency.
 - Added a reproducible multiplayer session verification harness at `scripts/verify_task_02_multiplayer_session_flow.py` that exercises sequential and simultaneous joins, repeated joins, timeout cleanup, reconnect-as-new-player, server restart recovery, and four-client snapshot consistency against the live UDP server.
 - Added focused client coverage for authoritative local-player selection so duplicate local `Player` entities cannot silently break gameplay systems that rely on `Query::single()`.
 - Added multiplayer session policy documentation and a `TASK-02` progress log with the recorded session matrix.

--- a/client/src/combat.rs
+++ b/client/src/combat.rs
@@ -11,6 +11,7 @@ use bevy::{
 
 use crate::camera::MainCamera;
 use crate::debug_console::DebugConsole;
+use crate::input_bindings::SKILL_CAST_KEYS;
 use crate::net::{
     GameState, GameStateSnapshot, NetworkCommand, NetworkMinion, NetworkMinionId,
     NetworkNeutral, NetworkNeutralId, NetworkPlayerId, NetworkStructure, NetworkStructureId,
@@ -21,6 +22,15 @@ use crate::team::Team;
 
 pub const MAX_HP: f32 = 100.0;
 pub const MAX_MANA: f32 = 100.0;
+
+/// Mirrors server `SPELL_COOLDOWN` for local HUD feedback until the snapshot exposes cooldowns.
+pub const LOCAL_CAST_COOLDOWN_SECS: f32 = 0.35;
+
+/// Local spell cooldown timer (all cast keys share one server action).
+#[derive(Resource, Default)]
+pub struct LocalCastCooldown {
+    pub remaining_secs: f32,
+}
 
 const BAR_WIDTH: f32 = 1.45;
 const BAR_HEIGHT: f32 = 0.09;
@@ -43,7 +53,8 @@ const MINION_MARKER_RADIUS: f32 = 1.05;
 const NEUTRAL_MARKER_RADIUS: f32 = 1.1;
 const TOWER_MARKER_RADIUS: f32 = 2.0;
 const BASE_TOWER_MARKER_RADIUS: f32 = 3.75;
-const SKILL_BUTTON_SIZE: f32 = 80.0;
+const SKILL_SLOT_SIZE: f32 = 64.0;
+const SKILL_SLOT_GAP: f32 = 8.0;
 const SKILL_BUTTON_MARGIN: f32 = 20.0;
 const SKILL_BUTTON_COLOR: Color = Color::srgba(0.12, 0.12, 0.12, 0.75);
 const SKILL_BUTTON_HOVER_COLOR: Color = Color::srgba(0.18, 0.18, 0.18, 0.85);
@@ -54,11 +65,13 @@ pub struct CombatPlugin;
 impl Plugin for CombatPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<TargetState>()
+            .init_resource::<LocalCastCooldown>()
             .add_systems(Startup, setup_combat_visual_assets)
             .add_systems(Startup, setup_combat_ui)
             .add_systems(
                 Update,
                 (
+                    tick_local_cast_cooldown,
                     select_target_system,
                     clear_invalid_target_system,
                     cast_spell_system,
@@ -114,9 +127,9 @@ struct CombatVisualAssets {
 }
 
 #[derive(Resource, Default)]
-struct TargetState {
-    selected_entity: Option<Entity>,
-    selected_target: Option<TargetId>,
+pub struct TargetState {
+    pub selected_entity: Option<Entity>,
+    pub selected_target: Option<TargetId>,
     marker_entity: Option<Entity>,
 }
 
@@ -130,7 +143,13 @@ struct CombatBars {
 struct TargetMarker;
 
 #[derive(Component)]
-struct SkillButton;
+struct SkillBarSlot;
+
+fn tick_local_cast_cooldown(time: Res<Time>, mut cd: ResMut<LocalCastCooldown>) {
+    if cd.remaining_secs > 0.0 {
+        cd.remaining_secs = (cd.remaining_secs - time.delta_secs()).max(0.0);
+    }
+}
 
 #[derive(Component)]
 struct CombatBarRoot;
@@ -248,22 +267,48 @@ fn setup_combat_visual_assets(
 }
 
 fn setup_combat_ui(mut commands: Commands) {
-    commands.spawn((
-        Button,
-        Node {
-            position_type: PositionType::Absolute,
-            right: Val::Px(SKILL_BUTTON_MARGIN),
-            bottom: Val::Px(SKILL_BUTTON_MARGIN),
-            width: Val::Px(SKILL_BUTTON_SIZE),
-            height: Val::Px(SKILL_BUTTON_SIZE),
-            justify_content: JustifyContent::Center,
-            align_items: AlignItems::Center,
-            ..default()
-        },
-        BackgroundColor(SKILL_BUTTON_COLOR),
-        SkillButton,
-        Name::new("SkillButton"),
-    ));
+    commands
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                right: Val::Px(SKILL_BUTTON_MARGIN),
+                bottom: Val::Px(SKILL_BUTTON_MARGIN),
+                flex_direction: FlexDirection::Row,
+                column_gap: Val::Px(SKILL_SLOT_GAP),
+                align_items: AlignItems::Center,
+                ..default()
+            },
+            ZIndex(12),
+            Name::new("SkillBarRoot"),
+        ))
+        .with_children(|row| {
+            for i in 0..4 {
+                let label = crate::input_bindings::SKILL_SLOT_KEY_LABELS[i];
+                row.spawn((
+                    Button,
+                    Node {
+                        width: Val::Px(SKILL_SLOT_SIZE),
+                        height: Val::Px(SKILL_SLOT_SIZE),
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    BackgroundColor(SKILL_BUTTON_COLOR),
+                    SkillBarSlot,
+                    Name::new(format!("SkillSlot-{label}")),
+                ))
+                .with_children(|slot| {
+                    slot.spawn((
+                        Text::new(label),
+                        TextFont {
+                            font_size: 22.0,
+                            ..default()
+                        },
+                        TextColor::WHITE,
+                    ));
+                });
+            }
+        });
 }
 
 fn select_target_system(
@@ -416,13 +461,20 @@ fn cast_spell_system(
     mut target_state: ResMut<TargetState>,
     mut command_writer: MessageWriter<NetworkCommand>,
     mut console: ResMut<DebugConsole>,
+    mut cast_cd: ResMut<LocalCastCooldown>,
 ) {
     if let Some(game_state) = game_state.as_ref() {
         if !matches!(game_state.state, GameState::Running) {
             return;
         }
     }
-    if !keyboard_input.just_pressed(KeyCode::KeyQ) {
+    let cast_pressed = SKILL_CAST_KEYS
+        .iter()
+        .any(|key| keyboard_input.just_pressed(*key));
+    if !cast_pressed {
+        return;
+    }
+    if cast_cd.remaining_secs > 0.0 {
         return;
     }
 
@@ -438,6 +490,7 @@ fn cast_spell_system(
     );
     let target = resolve_cast_target(&mut target_state);
     if let Some(target) = target {
+        cast_cd.remaining_secs = LOCAL_CAST_COOLDOWN_SECS;
         command_writer.write(NetworkCommand::Cast { target });
         let message = format!(
             "Cast -> {} {} (mana {:.0})",
@@ -462,7 +515,7 @@ fn cast_spell_system(
 fn skill_button_system(
     mut interactions: Query<
         (&Interaction, &mut BackgroundColor),
-        (Changed<Interaction>, With<SkillButton>),
+        (Changed<Interaction>, With<SkillBarSlot>),
     >,
     game_state: Option<Res<GameStateSnapshot>>,
     local_stats_query: Query<&CombatStats, With<Player>>,
@@ -493,6 +546,7 @@ fn skill_button_system(
     mut target_state: ResMut<TargetState>,
     mut command_writer: MessageWriter<NetworkCommand>,
     mut console: ResMut<DebugConsole>,
+    mut cast_cd: ResMut<LocalCastCooldown>,
 ) {
     if let Some(game_state) = game_state.as_ref() {
         if !matches!(game_state.state, GameState::Running) {
@@ -503,6 +557,9 @@ fn skill_button_system(
         match *interaction {
             Interaction::Pressed => {
                 *color = SKILL_BUTTON_PRESS_COLOR.into();
+                if cast_cd.remaining_secs > 0.0 {
+                    continue;
+                }
                 let Ok(local_stats) = local_stats_query.single() else {
                     continue;
                 };
@@ -514,6 +571,7 @@ fn skill_button_system(
                     &structure_candidates,
                 );
                 if let Some(target) = resolve_cast_target(&mut target_state) {
+                    cast_cd.remaining_secs = LOCAL_CAST_COOLDOWN_SECS;
                     command_writer.write(NetworkCommand::Cast { target });
                     let message = format!(
                         "Cast -> {} {} (mana {:.0})",

--- a/client/src/game_state.rs
+++ b/client/src/game_state.rs
@@ -96,10 +96,11 @@ fn update_game_state_ui(
                     winner.as_str()
                 )
             };
+            let next_steps = "\nPress Escape for the menu. Wait for an automatic rematch countdown when shown, or restart the client from the pause menu if needed.";
             label.0 = if let Some(secs) = game_state.rematch_in_secs {
-                format!("{base_msg}\nRematch in {secs}s...")
+                format!("{base_msg}\nRematch in {secs}s...{next_steps}")
             } else {
-                base_msg
+                format!("{base_msg}{next_steps}")
             };
         }
     }

--- a/client/src/help_overlay.rs
+++ b/client/src/help_overlay.rs
@@ -1,0 +1,177 @@
+//! Toggleable controls and onboarding copy. Does not despawn gameplay entities.
+
+use bevy::prelude::*;
+
+use crate::input_bindings::{HELP_TOGGLE_KEY, help_key_display, skill_keys_display, upgrade_key_display};
+use crate::net::{GameState, GameStateSnapshot};
+
+pub struct HelpOverlayPlugin;
+
+impl Plugin for HelpOverlayPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<HelpOverlayVisible>()
+            .init_resource::<HelpAutoShowState>()
+            .add_systems(Startup, setup_help_overlay)
+            .add_systems(
+                Update,
+                (
+                    auto_show_help_on_first_match_start,
+                    toggle_help_overlay,
+                    sync_help_overlay_visibility,
+                )
+                    .chain(),
+            );
+    }
+}
+
+/// One-time prompt when the match first enters Running (session scope).
+#[derive(Resource)]
+struct HelpAutoShowState {
+    pending: bool,
+    was_running: bool,
+}
+
+impl Default for HelpAutoShowState {
+    fn default() -> Self {
+        Self {
+            pending: true,
+            was_running: false,
+        }
+    }
+}
+
+fn auto_show_help_on_first_match_start(
+    snapshot: Res<GameStateSnapshot>,
+    mut state: ResMut<HelpAutoShowState>,
+    mut visible: ResMut<HelpOverlayVisible>,
+) {
+    let running = matches!(snapshot.state, GameState::Running);
+    if running && !state.was_running && state.pending {
+        visible.0 = true;
+        state.pending = false;
+    }
+    state.was_running = running;
+}
+
+#[derive(Resource, Default)]
+pub struct HelpOverlayVisible(pub bool);
+
+#[derive(Component)]
+struct HelpOverlayRoot;
+
+#[derive(Component)]
+struct HelpOverlayPanel;
+
+fn setup_help_overlay(mut commands: Commands) {
+    let body = help_overlay_body();
+
+    commands
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                left: Val::Px(0.0),
+                right: Val::Px(0.0),
+                top: Val::Px(72.0),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::FlexStart,
+                ..default()
+            },
+            Visibility::Hidden,
+            ZIndex(40),
+            HelpOverlayRoot,
+            Name::new("HelpOverlayRoot"),
+        ))
+        .with_children(|parent| {
+            parent
+                .spawn((
+                    Node {
+                        width: Val::Percent(88.0),
+                        max_width: Val::Px(520.0),
+                        padding: UiRect::all(Val::Px(18.0)),
+                        ..default()
+                    },
+                    BackgroundColor(Color::srgba(0.04, 0.05, 0.08, 0.92)),
+                    BorderColor::all(Color::srgba(0.5, 0.55, 0.62, 0.85)),
+                ))
+                .with_children(|panel| {
+                    panel.spawn((
+                        Text::new(body),
+                        TextFont {
+                            font_size: 16.0,
+                            ..default()
+                        },
+                        TextColor(Color::WHITE),
+                        HelpOverlayPanel,
+                    ));
+                });
+        });
+}
+
+fn toggle_help_overlay(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut visible: ResMut<HelpOverlayVisible>,
+) {
+    if !keyboard.just_pressed(HELP_TOGGLE_KEY) {
+        return;
+    }
+    visible.0 = !visible.0;
+}
+
+fn sync_help_overlay_visibility(
+    visible: Res<HelpOverlayVisible>,
+    snapshot: Res<GameStateSnapshot>,
+    mut root: Query<&mut Visibility, With<HelpOverlayRoot>>,
+) {
+    let in_running_match = matches!(snapshot.state, GameState::Running);
+    if !visible.is_changed() && !snapshot.is_changed() {
+        return;
+    }
+    let Ok(mut v) = root.single_mut() else {
+        return;
+    };
+    // Keep lobby/victory overlays readable (game state UI sits below this z-order).
+    let show_panel = visible.0 && in_running_match;
+    *v = if show_panel {
+        Visibility::Visible
+    } else {
+        Visibility::Hidden
+    };
+}
+
+fn help_overlay_body() -> String {
+    let help_key = help_key_display();
+    let skills = skill_keys_display();
+    let upgrade = upgrade_key_display();
+    format!(
+        "Quick guide (press {help_key} to close)\n\n\
+MOVE: Left-click the ground to walk.\n\
+CAMERA: Mouse wheel zoom. Right-click or Alt toggles free camera; use WASD + Q/E while free.\n\
+MINIMAP: Top-left — click to move the camera focus.\n\
+TARGET: Tab selects nearest hostile, middle-click near units/structures, Backspace clears.\n\
+CAST: Skill keys {skills} — same ability on each key until the server adds separate skills.\n\
+SKILL POINTS: Spend with {upgrade} when the upgrade flow is wired (binding reserved).\n\
+OBJECTIVE: Destroy the enemy base tower.\n\
+PAUSE: Escape opens the menu."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn help_overlay_copy_covers_core_first_match_actions() {
+        let body = help_overlay_body();
+        assert!(body.contains("MOVE:"));
+        assert!(body.contains("TARGET:"));
+        assert!(body.contains("CAST:"));
+        assert!(body.contains("OBJECTIVE:"));
+        assert!(body.contains(&skill_keys_display()));
+    }
+
+    #[test]
+    fn help_overlay_copy_includes_toggle_hint() {
+        let body = help_overlay_body();
+        assert!(body.contains("press F1"));
+    }
+}

--- a/client/src/input_bindings.rs
+++ b/client/src/input_bindings.rs
@@ -1,0 +1,74 @@
+//! Central keybinding labels for combat HUD and help copy.
+//! Keep cast handling in `combat.rs` in sync with `SKILL_CAST_KEYS`.
+
+use bevy::prelude::KeyCode;
+
+/// Keys that trigger a cast toward the current target (same server action until skill slots exist).
+pub const SKILL_CAST_KEYS: [KeyCode; 4] = [
+    KeyCode::KeyQ,
+    KeyCode::KeyW,
+    KeyCode::KeyE,
+    KeyCode::KeyR,
+];
+
+/// Reserved for future skill-upgrade UI; keep in sync with `upgrade_key_display()`.
+#[allow(dead_code)]
+pub const SKILL_UPGRADE_KEY: KeyCode = KeyCode::KeyU;
+
+pub const HELP_TOGGLE_KEY: KeyCode = KeyCode::F1;
+
+/// Human-readable primary labels for the four cast slots (matches `SKILL_CAST_KEYS` order).
+pub const SKILL_SLOT_KEY_LABELS: [&str; 4] = ["Q", "W", "E", "R"];
+
+/// Compact list for help/HUD copy; stays aligned with [`SKILL_SLOT_KEY_LABELS`].
+pub fn skill_keys_display() -> String {
+    SKILL_SLOT_KEY_LABELS.join(" / ")
+}
+
+/// Four bracketed slot labels for at-a-glance HUD (e.g. `[Q]  [W]  [E]  [R]`).
+pub fn skill_slots_bracket_line() -> String {
+    SKILL_SLOT_KEY_LABELS
+        .iter()
+        .map(|k| format!("[{k}]"))
+        .collect::<Vec<_>>()
+        .join("  ")
+}
+
+pub fn upgrade_key_display() -> &'static str {
+    "U"
+}
+
+pub fn help_key_display() -> &'static str {
+    "F1"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cast_keys_and_slot_labels_same_length() {
+        assert_eq!(SKILL_CAST_KEYS.len(), SKILL_SLOT_KEY_LABELS.len());
+    }
+
+    #[test]
+    fn skill_keys_display_covers_every_slot_label() {
+        let s = skill_keys_display();
+        for label in SKILL_SLOT_KEY_LABELS {
+            assert!(
+                s.contains(label),
+                "expected {s:?} to contain slot label {label:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn skill_slots_bracket_line_has_four_brackets() {
+        let s = skill_slots_bracket_line();
+        assert_eq!(s.matches('[').count(), 4);
+        assert_eq!(s.matches(']').count(), 4);
+        for label in SKILL_SLOT_KEY_LABELS {
+            assert!(s.contains(&format!("[{label}]")));
+        }
+    }
+}

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -4,7 +4,10 @@ mod camera;
 mod combat;
 mod debug_console;
 mod game_state;
+mod help_overlay;
+mod input_bindings;
 mod maps;
+mod match_hud;
 mod minimap;
 mod net;
 mod pause_menu;
@@ -16,6 +19,8 @@ use camera::CameraPlugin;
 use combat::CombatPlugin;
 use debug_console::DebugConsolePlugin;
 use game_state::GameStateUiPlugin;
+use help_overlay::HelpOverlayPlugin;
+use match_hud::MatchHudPlugin;
 use maps::MapsPlugin;
 use minimap::MinimapPlugin;
 use net::NetworkingPlugin;
@@ -38,8 +43,10 @@ fn main() {
             NetworkingPlugin,
             MinimapPlugin,
             CombatPlugin,
+            MatchHudPlugin,
             TeamSelectPlugin,
             GameStateUiPlugin,
+            HelpOverlayPlugin,
             DebugConsolePlugin,
             PauseMenuPlugin,
         ))

--- a/client/src/match_hud.rs
+++ b/client/src/match_hud.rs
@@ -1,0 +1,251 @@
+//! In-match HUD: progression, local HP/mana, target summary, objective hint, and key hints.
+
+use bevy::prelude::*;
+
+use crate::combat::{CombatStats, LocalCastCooldown, TargetState};
+use crate::input_bindings::{
+    help_key_display, skill_keys_display, skill_slots_bracket_line, upgrade_key_display,
+};
+use crate::net::{
+    GameState, GameStateSnapshot, NetworkStructure, PlayerProgression, StructureKind, TargetId,
+    TargetKind,
+};
+use crate::player::Player;
+use crate::team::Team;
+
+pub struct MatchHudPlugin;
+
+impl Plugin for MatchHudPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, setup_match_hud)
+            .add_systems(Update, update_match_hud);
+    }
+}
+
+#[derive(Component)]
+struct MatchHudProgressionText;
+
+#[derive(Component)]
+struct MatchHudStatusText;
+
+const HUD_LEFT: f32 = 16.0;
+/// Below the minimap (minimap top margin + outer size ~ 236px).
+const HUD_TOP: f32 = 248.0;
+
+fn setup_match_hud(mut commands: Commands) {
+    commands
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                left: Val::Px(HUD_LEFT),
+                top: Val::Px(HUD_TOP),
+                flex_direction: FlexDirection::Column,
+                row_gap: Val::Px(6.0),
+                max_width: Val::Px(420.0),
+                ..default()
+            },
+            ZIndex(8),
+            Name::new("MatchHudColumn"),
+        ))
+        .with_children(|col| {
+            col.spawn((
+                Text::new("Level --   XP --/--   Skill points --"),
+                TextFont {
+                    font_size: 22.0,
+                    ..default()
+                },
+                TextColor::WHITE,
+                MatchHudProgressionText,
+            ));
+            col.spawn((
+                Text::new(""),
+                TextFont {
+                    font_size: 17.0,
+                    ..default()
+                },
+                TextColor(Color::srgba(0.88, 0.90, 0.94, 1.0)),
+                MatchHudStatusText,
+            ));
+        });
+}
+
+fn update_match_hud(
+    game_state: Option<Res<GameStateSnapshot>>,
+    player: Query<(&CombatStats, &PlayerProgression), With<Player>>,
+    local_team: Query<&Team, With<Player>>,
+    enemy_bases: Query<(&CombatStats, &Team, &StructureKind), With<NetworkStructure>>,
+    cast_cd: Res<LocalCastCooldown>,
+    target_state: Res<TargetState>,
+    mut prog: Query<&mut Text, With<MatchHudProgressionText>>,
+    mut status: Query<&mut Text, With<MatchHudStatusText>>,
+) {
+    let Ok(mut prog_text) = prog.single_mut() else {
+        return;
+    };
+    let Ok(mut status_text) = status.single_mut() else {
+        return;
+    };
+
+    let Some((stats, progression)) = player.iter().next() else {
+        prog_text.0 = "Level --   XP --/--   Skill points --".into();
+        status_text.0.clear();
+        return;
+    };
+
+    let running = game_state
+        .as_ref()
+        .is_some_and(|g| matches!(g.state, GameState::Running));
+
+    let up = upgrade_key_display();
+    if progression.next_level_xp == 0 {
+        prog_text.0 = format!(
+            "Level {}   XP MAX   Skill points {}   Upgrade: {} (when available)",
+            progression.level.max(1),
+            progression.skill_points,
+            up
+        );
+    } else {
+        let displayed_xp = progression.xp.min(progression.next_level_xp);
+        prog_text.0 = format!(
+            "Level {}   XP {}/{}   Skill points {}   Upgrade: {} (when available)",
+            progression.level.max(1),
+            displayed_xp,
+            progression.next_level_xp,
+            progression.skill_points,
+            up
+        );
+    }
+
+    if !running {
+        status_text.0 = format!(
+            "Press {} for controls help.\nSkills: {} — cast on target.",
+            help_key_display(),
+            skill_keys_display()
+        );
+        return;
+    }
+
+    let objective_line = enemy_base_objective_line(&local_team, &enemy_bases);
+    status_text.0 = running_status_text(
+        *stats,
+        target_state.selected_target,
+        &objective_line,
+        cast_cd.remaining_secs,
+    );
+}
+
+fn running_status_text(
+    stats: CombatStats,
+    selected_target: Option<TargetId>,
+    objective_line: &str,
+    cooldown_remaining_secs: f32,
+) -> String {
+    let slots_line = format!("Skill slots: {} (same cast, shared CD)", skill_slots_bracket_line());
+    let cast_line = if cooldown_remaining_secs > 0.0 {
+        format!("Spell cooldown: {:.1}s (shared)", cooldown_remaining_secs)
+    } else {
+        format!("Spell ready — {} (shared cooldown)", skill_keys_display())
+    };
+    let target_line = match selected_target {
+        Some(t) => {
+            let kind = match t.kind {
+                TargetKind::Player => "Player",
+                TargetKind::Minion => "Minion",
+                TargetKind::Structure => "Structure",
+                TargetKind::Neutral => "Neutral",
+            };
+            format!("Target: {kind} #{}", t.id)
+        }
+        None => "Target: none — Tab (nearest foe), middle-click near foe, Backspace clear".to_string(),
+    };
+    let hp = stats.hp.max(0.0);
+    let max_hp = stats.max_hp.max(1.0);
+    let mana = stats.mana.max(0.0);
+    let max_mana = stats.max_mana.max(1.0);
+    format!(
+        "HP {:.0}/{:.0}   Mana {:.0}/{:.0}\n\
+{target_line}\n\
+{objective_line}\n\
+{slots_line}\n\
+{cast_line}\n\
+Keys: {} — cast on target   |   Upgrade {}   |   {} help",
+        hp,
+        max_hp,
+        mana,
+        max_mana,
+        skill_keys_display(),
+        upgrade_key_display(),
+        help_key_display()
+    )
+}
+
+fn enemy_base_objective_line(
+    local_team: &Query<&Team, With<Player>>,
+    structures: &Query<(&CombatStats, &Team, &StructureKind), With<NetworkStructure>>,
+) -> String {
+    let Ok(team) = local_team.single() else {
+        return "Goal: destroy the enemy base tower.".to_string();
+    };
+    let mut hp_sum = 0.0f32;
+    let mut max_sum = 0.0f32;
+    let mut any = false;
+    for (stats, st_team, kind) in structures.iter() {
+        if *kind == StructureKind::BaseTower && *st_team != *team {
+            hp_sum += stats.hp.max(0.0);
+            max_sum += stats.max_hp.max(0.0);
+            any = true;
+        }
+    }
+    if any && max_sum > 0.0 {
+        format!(
+            "Goal: destroy enemy base — {:.0} / {:.0} HP remaining",
+            hp_sum.min(max_sum),
+            max_sum
+        )
+    } else {
+        "Goal: destroy the enemy base tower.".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn running_status_text_shows_resources_and_objective() {
+        let text = running_status_text(
+            CombatStats {
+                hp: 75.0,
+                max_hp: 100.0,
+                mana: 40.0,
+                max_mana: 100.0,
+            },
+            None,
+            "Goal: destroy enemy base — 650 / 650 HP remaining",
+            0.0,
+        );
+        assert!(text.contains("HP 75/100   Mana 40/100"));
+        assert!(text.contains("Goal: destroy enemy base"));
+        assert!(text.contains("Spell ready"));
+    }
+
+    #[test]
+    fn running_status_text_shows_target_and_cooldown() {
+        let text = running_status_text(
+            CombatStats {
+                hp: 90.0,
+                max_hp: 120.0,
+                mana: 12.0,
+                max_mana: 60.0,
+            },
+            Some(TargetId {
+                kind: TargetKind::Player,
+                id: 42,
+            }),
+            "Goal: destroy enemy base",
+            1.26,
+        );
+        assert!(text.contains("Target: Player #42"));
+        assert!(text.contains("Spell cooldown: 1.3s"));
+    }
+}

--- a/client/src/player.rs
+++ b/client/src/player.rs
@@ -14,7 +14,7 @@ use crate::debug_console::DebugConsole;
 use crate::maps::MapLayout;
 use crate::minimap::MinimapNavigationState;
 use crate::net::{
-    GameState, GameStateSnapshot, NetworkCharacterChoice, NetworkStructure, PlayerProgression,
+    GameState, GameStateSnapshot, NetworkCharacterChoice, NetworkStructure,
     RemotePlayer, StructureKind,
 };
 use crate::team::{CharacterChoice, Team};
@@ -54,8 +54,8 @@ impl Plugin for PlayerPlugin {
         .add_systems(PostUpdate, apply_gravity)
         .init_resource::<RespawnCountdown>()
         .init_resource::<PlayerAnimationLibrary>()
-        .add_systems(Startup, (setup_respawn_ui, setup_progression_ui))
-        .add_systems(Update, (respawn_countdown_system, progression_hud_system));
+        .add_systems(Startup, setup_respawn_ui)
+        .add_systems(Update, respawn_countdown_system);
     }
 }
 
@@ -87,9 +87,6 @@ impl Default for RespawnCountdown {
 
 #[derive(Component)]
 struct RespawnCountdownText;
-
-#[derive(Component)]
-struct ProgressionHudText;
 
 #[derive(Component)]
 struct MovementTarget {
@@ -624,61 +621,6 @@ fn setup_respawn_ui(mut commands: Commands) {
                 RespawnCountdownText,
             ));
         });
-}
-
-fn setup_progression_ui(mut commands: Commands) {
-    commands
-        .spawn((
-            Node {
-                position_type: PositionType::Absolute,
-                left: Val::Px(16.0),
-                top: Val::Px(16.0),
-                ..default()
-            },
-            Name::new("ProgressionHud"),
-        ))
-        .with_children(|parent| {
-            parent.spawn((
-                Text::new("Level --   XP --/--   Skill points --"),
-                TextFont {
-                    font_size: 24.0,
-                    ..default()
-                },
-                TextColor(Color::WHITE),
-                ProgressionHudText,
-            ));
-        });
-}
-
-fn progression_hud_system(
-    player_query: Query<&PlayerProgression, With<Player>>,
-    mut text_query: Query<&mut Text, With<ProgressionHudText>>,
-) {
-    let Ok(mut text) = text_query.single_mut() else {
-        return;
-    };
-
-    let Some(progression) = player_query.iter().next() else {
-        text.0 = "Level --   XP --/--   Skill points --".to_string();
-        return;
-    };
-
-    if progression.next_level_xp == 0 {
-        text.0 = format!(
-            "Level {}   XP MAX   Skill points {}",
-            progression.level.max(1),
-            progression.skill_points
-        );
-    } else {
-        let displayed_xp = progression.xp.min(progression.next_level_xp);
-        text.0 = format!(
-            "Level {}   XP {}/{}   Skill points {}",
-            progression.level.max(1),
-            displayed_xp,
-            progression.next_level_xp,
-            progression.skill_points
-        );
-    }
 }
 
 fn respawn_countdown_system(

--- a/docs/features.md
+++ b/docs/features.md
@@ -10,7 +10,8 @@ Canonical version: `0.2.0`
 - Core combat loop with projectiles, structures, minions, death, respawn, mana regeneration, and base-destruction win condition.
 - Map layout with three lanes and simple jungle blocks.
 - Player progression with level-based XP thresholds, HP/mana scaling on level-up, and tracked skill points.
-- In-game local HUD display for level and XP progression.
+- In-game match HUD (below minimap): level, XP, skill points, reserved upgrade key label (`U`), local HP/mana, target hints, objective line, and F1 help reminder; bottom-right skill bar showing `Q`–`R` keys (same cast binding until per-skill server support).
+- F1 toggle help overlay with movement, camera, targeting, casting, objective, and pause guidance; does not reset simulation when toggled. The panel is shown only while the match is `Running` (toggle state is preserved when returning to a live match so lobby/victory screens are not covered).
 
 ## Multiplayer Session Reliability
 


### PR DESCRIPTION
## Summary
- Complete onboarding/help UX and in-match HUD clarity with cooldown-aligned behavior.
- Keep the branch scoped to TASK-13 acceptance criteria and verifier outcomes.
- Preserve isolated worktree history for easier review.

## Test plan
- [x] Run branch build/test checks captured in task evidence.
- [x] Run a fresh verifier pass for TASK-13.
- [ ] Optional manual gameplay smoke before merge.

Made with [Cursor](https://cursor.com)