### PR TITLE
TASK-14: harden client session lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The canonical repository version lives in `Cargo.toml` under `[workspace.package
 ## [Unreleased]
 
 ### Added
+- **TASK-14**: Client connection lifecycle (`Connecting` / `WaitingForServer` / `Connected` / `Disconnected`), bounded wait and stale-snapshot handling with named thresholds in `session_config`, transport failure signaling from the UDP thread, teardown that clears replicated entities and re-opens team select, manual **Retry** after disconnect, ingest/apply snapshot pipeline ordering for Bevy 0.18, snapshot-channel disconnect detection (`NetIncomingDisconnected`), pause menu closes on **Disconnected**, minimap visible only while **Connected**, preferences save when the resolved server address resource updates, settings panel shows current server address text, and `docs/network-client-session.md` for constants and manual QA cross-reference.
+- Client preferences file: graphics (lighting, model scale), character selection, and optional `game_server_addr` with load precedence `GAME_SERVER_ADDR` → saved file → default; pause menu **Reset graphics to defaults**; paths documented in `client/src/persistence.rs` and `RUNBOOK.md`.
 - Added a reproducible multiplayer session verification harness at `scripts/verify_task_02_multiplayer_session_flow.py` that exercises sequential and simultaneous joins, repeated joins, timeout cleanup, reconnect-as-new-player, server restart recovery, and four-client snapshot consistency against the live UDP server.
 - Added focused client coverage for authoritative local-player selection so duplicate local `Player` entities cannot silently break gameplay systems that rely on `Query::single()`.
 - Added multiplayer session policy documentation and a `TASK-02` progress log with the recorded session matrix.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -93,3 +93,18 @@ After an abnormal termination (e.g. `kill -9`):
 2. Run `make start` (or `make restart` which does both automatically).
 
 No code edits are required between restarts.
+
+## TASK-14 — Network failure and session resilience (manual QA)
+
+Use two terminals (or `make start` / `make stop`). Constants live in `client/src/session_config.rs`.
+
+| Step | Action | Expected client state / UI |
+|------|--------|----------------------------|
+| 1 | Start **client only** (no server) | **WaitingForServer** (or brief **Connecting**): panel explains address, retry interval, max wait; viewport keeps rendering; after `T_WAIT_MAX` → **Disconnected** with **Retry** visible. |
+| 2 | Start server while client waits or after **Retry** | First qualifying snapshot → **Connected**; status text updates; join flow works. |
+| 3 | Reach **Connected**, play briefly, **kill server** | Within `T_STALE_SNAPSHOT` (or transport threshold if errors surface), **Disconnected**; replicated world cleared; team select returns; game-state overlay hidden. |
+| 4 | Restart server, click **Retry**, join again | Returns to normal **Connected** flow (manual path — no auto-rejoin into match). If the client UDP thread exited (e.g. bind failure), restart the client instead — **Retry** does not respawn that thread. |
+| 5 | Spam team join (double-click / rapid confirm) | At most one local `Player` after sync; `Join` idempotent while `join_flow_committed`. |
+| 6 | Block UDP (e.g. firewall) while **Connected** | Stale snapshot or transport rule → **Disconnected** same as server kill. |
+
+**Preferences file** (optional server address + graphics): see `client/src/persistence.rs` (`OMOBA_CLIENT_CONFIG_DIR` or default OS path). **Env wins** over saved `game_server_addr` when `GAME_SERVER_ADDR` is set and non-empty.

--- a/client/src/camera.rs
+++ b/client/src/camera.rs
@@ -155,7 +155,10 @@ fn update_camera(
         let follow_target = if let Some(override_target) = focus_override {
             Some(override_target)
         } else {
-            player_query.single().ok().map(|transform| transform.translation)
+            player_query
+                .single()
+                .ok()
+                .map(|transform| transform.translation)
         };
         if let Some(target) = follow_target {
             let zoom = cam_state.zoom;

--- a/client/src/combat.rs
+++ b/client/src/combat.rs
@@ -12,9 +12,9 @@ use bevy::{
 use crate::camera::MainCamera;
 use crate::debug_console::DebugConsole;
 use crate::net::{
-    GameState, GameStateSnapshot, NetworkCommand, NetworkMinion, NetworkMinionId,
-    NetworkNeutral, NetworkNeutralId, NetworkPlayerId, NetworkStructure, NetworkStructureId,
-    RemotePlayer, StructureKind, TargetId, TargetKind,
+    GameState, GameStateSnapshot, NetworkCommand, NetworkMinion, NetworkMinionId, NetworkNeutral,
+    NetworkNeutralId, NetworkPlayerId, NetworkStructure, NetworkStructureId, RemotePlayer,
+    StructureKind, TargetId, TargetKind,
 };
 use crate::player::Player;
 use crate::team::Team;
@@ -563,9 +563,8 @@ fn spawn_combat_bars_system(
             Some(StructureKind::BaseTower) => BASE_TOWER_BAR_Y,
             None => 2.1,
         };
-        let show_mana_bar = structure_kind.is_none()
-            && minion_marker.is_none()
-            && neutral_marker.is_none();
+        let show_mana_bar =
+            structure_kind.is_none() && minion_marker.is_none() && neutral_marker.is_none();
         let mut bars = CombatBars::default();
         let bar_root = commands
             .spawn((
@@ -789,7 +788,8 @@ fn update_target_marker_system(
         marker_center_y + bob,
         target_translation.z,
     );
-    marker_transform.rotation = Quat::from_rotation_y(time.elapsed_secs() * TARGET_MARKER_SPIN_SPEED);
+    marker_transform.rotation =
+        Quat::from_rotation_y(time.elapsed_secs() * TARGET_MARKER_SPIN_SPEED);
     marker_transform.scale = Vec3::new(marker_radius * pulse, 1.0, marker_radius * pulse);
 }
 

--- a/client/src/game_state.rs
+++ b/client/src/game_state.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 
-use crate::net::{GameState, GameStateSnapshot};
+use crate::net::{ClientSession, GameState, GameStateSnapshot};
 use crate::player::Player;
 use crate::team::Team;
 
@@ -59,6 +59,7 @@ fn setup_game_state_ui(mut commands: Commands) {
 
 fn update_game_state_ui(
     game_state: Res<GameStateSnapshot>,
+    client_session: Res<ClientSession>,
     local_team: Query<&Team, With<Player>>,
     mut overlay_query: Query<(&mut Visibility, &mut BackgroundColor), With<GameStateOverlay>>,
     mut text_query: Query<&mut Text, With<GameStateLabel>>,
@@ -69,6 +70,13 @@ fn update_game_state_ui(
     let Ok(mut label) = text_query.single_mut() else {
         return;
     };
+
+    if !client_session.is_connected() {
+        *visibility = Visibility::Hidden;
+        *background = BackgroundColor(Color::NONE);
+        label.0.clear();
+        return;
+    }
 
     match game_state.state {
         GameState::Lobby => {
@@ -83,7 +91,7 @@ fn update_game_state_ui(
         }
         GameState::Victory { winner } => {
             *visibility = Visibility::Visible;
-            let is_winner = local_team.single().is_ok_and(|team| *team == winner);
+            let is_winner = local_team.iter().next().is_some_and(|team| *team == winner);
             *background = BackgroundColor(if is_winner { WIN_COLOR } else { LOSE_COLOR });
             let base_msg = if is_winner {
                 format!(

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -8,7 +8,9 @@ mod maps;
 mod minimap;
 mod net;
 mod pause_menu;
+mod persistence;
 mod player;
+mod session_config;
 mod team;
 mod world;
 
@@ -20,6 +22,7 @@ use maps::MapsPlugin;
 use minimap::MinimapPlugin;
 use net::NetworkingPlugin;
 use pause_menu::PauseMenuPlugin;
+use persistence::ClientPersistencePlugin;
 use player::PlayerPlugin;
 use team::TeamSelectPlugin;
 use world::SetupPlugin;
@@ -34,6 +37,7 @@ fn main() {
             CameraPlugin,
             PlayerPlugin,
             MapsPlugin,
+            ClientPersistencePlugin,
             SetupPlugin,
             NetworkingPlugin,
             MinimapPlugin,

--- a/client/src/minimap.rs
+++ b/client/src/minimap.rs
@@ -4,8 +4,8 @@ use std::collections::{HashMap, HashSet};
 use crate::camera::CameraState;
 use crate::combat::CombatStats;
 use crate::maps::MapLayout;
+use crate::net::{ClientSession, NetworkMinion, NetworkStructure, RemotePlayer, StructureKind};
 use crate::player::PLAYER_SIZE;
-use crate::net::{NetworkMinion, NetworkStructure, RemotePlayer, StructureKind};
 use crate::player::Player;
 use crate::team::Team;
 
@@ -27,7 +27,13 @@ impl Plugin for MinimapPlugin {
             .init_resource::<MinimapNavigationState>()
             .add_systems(Startup, setup_minimap_ui)
             .add_systems(PreUpdate, handle_minimap_navigation_system)
-            .add_systems(PostUpdate, update_minimap_icons_system);
+            .add_systems(
+                PostUpdate,
+                (
+                    update_minimap_icons_system,
+                    sync_minimap_visibility_for_session.after(update_minimap_icons_system),
+                ),
+            );
     }
 }
 
@@ -234,6 +240,20 @@ fn update_minimap_icons_system(
         );
     }
     despawn_removed_icons(&mut commands, &mut state.minion_icons, &seen_minions);
+}
+
+fn sync_minimap_visibility_for_session(
+    client_session: Res<ClientSession>,
+    mut roots: Query<&mut Visibility, With<MinimapRoot>>,
+) {
+    let vis = if client_session.is_connected() {
+        Visibility::Visible
+    } else {
+        Visibility::Hidden
+    };
+    for mut v in &mut roots {
+        *v = vis;
+    }
 }
 
 fn sync_minimap_icon(

--- a/client/src/net.rs
+++ b/client/src/net.rs
@@ -13,17 +13,20 @@ use std::{
 
 use crate::camera::{CameraState, MainCamera, locked_camera_offset};
 use crate::combat::{CombatStats, MAX_HP, MAX_MANA};
+use crate::persistence::{FileGameServerAddr, ResolvedServerAddressForPrefs};
 use crate::player::{PLAYER_SIZE, Player, PlayerBody, VerticalVelocity};
+use crate::session_config::{
+    DEFAULT_GAME_SERVER_ADDR, T_RETRY, T_STALE_SNAPSHOT, T_WAIT_MAX,
+    TRANSPORT_CONSECUTIVE_RECV_ERRORS, TRANSPORT_CONSECUTIVE_SEND_ERRORS, is_stale,
+};
 use crate::team::TeamSelection;
-use crate::team::{CharacterChoice, Team};
+use crate::team::{CharacterChoice, Team, TeamSelectRoot, spawn_team_select_ui};
 use crate::world::{
     NormalizeModelScale, PlayerAssets, PlayerModelCatalog, model_assets_for_choice,
 };
 
-const DEFAULT_SERVER_ADDR: &str = "127.0.0.1:4000";
 const LOCAL_BIND_ADDR: &str = "0.0.0.0:0";
 const UPDATE_INTERVAL_SECONDS: f32 = 0.05;
-const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
 const NETWORK_LOOP_SLEEP: Duration = Duration::from_millis(16);
 const MAX_PACKET_SIZE: usize = 8 * 1024;
 const PROJECTILE_RADIUS: f32 = 0.22;
@@ -37,41 +40,174 @@ const LOCAL_SNAP_DISTANCE: f32 = 4.0;
 const DEFAULT_PLAYER_LEVEL: u32 = 1;
 const DEFAULT_NEXT_LEVEL_XP: u32 = 120;
 
+/// High-level client session / transport state (TASK-14 frozen connection states).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum ClientConnectionState {
+    /// Binding socket / spawning I/O thread (single-frame or brief).
+    #[default]
+    Connecting,
+    /// Transport up; no qualifying snapshot yet for this connect attempt.
+    WaitingForServer,
+    /// At least one qualifying snapshot applied; `your_id` is known.
+    Connected,
+    /// Session not live; user must use Retry or pick team again as documented.
+    Disconnected,
+}
+
+/// Signal from the UDP thread to the Bevy main thread (failure detection §3 in spec).
+#[derive(Debug, Clone, Copy)]
+pub enum NetThreadSignal {
+    /// Recv/send error streak exceeded fixed thresholds (P3 transport rule).
+    TransportFailure,
+}
+
+#[derive(Message, Clone, Copy, Debug)]
+pub enum SessionUiCommand {
+    /// User explicitly resumes waiting for snapshots after **Disconnected** (P2 manual recovery).
+    Retry,
+}
+
+/// Set by [`ingest_server_snapshot_packets`] when the UDP thread dropped the snapshot sender
+/// (failure detection §3: channel implies session ended).
+#[derive(Resource, Default)]
+pub struct NetIncomingDisconnected(pub bool);
+
+/// Session controller: owns lifecycle flags and join idempotency (single ownership vs UI/net).
+#[derive(Resource)]
+pub struct ClientSession {
+    pub state: ClientConnectionState,
+    /// Wall time when **WaitingForServer** began for the current attempt.
+    pub waiting_since: Option<Instant>,
+    /// Last time a qualifying snapshot was applied while **Connected**.
+    pub last_qualifying_snapshot_wall: Option<Instant>,
+    /// While true, incoming snapshots are drained and ignored (no silent re-entry to gameplay).
+    pub discard_incoming_snapshots: bool,
+    /// **P4**: after a join packet is sent, suppress duplicate join until teardown.
+    pub join_flow_committed: bool,
+    /// Server address used for this process (for UI copy).
+    pub server_addr_display: String,
+}
+
+impl Default for ClientSession {
+    fn default() -> Self {
+        Self {
+            state: ClientConnectionState::Connecting,
+            waiting_since: None,
+            last_qualifying_snapshot_wall: None,
+            discard_incoming_snapshots: false,
+            join_flow_committed: false,
+            server_addr_display: String::new(),
+        }
+    }
+}
+
+impl ClientSession {
+    pub fn is_connected(&self) -> bool {
+        self.state == ClientConnectionState::Connected
+    }
+}
+
 pub struct NetworkingPlugin;
+
+/// Strict main-thread ordering for networking / snapshot / UI sync (Bevy 0.18: avoid `.after(fn)`).
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+enum ClientNetPipeline {
+    SendLocalState,
+    SendCommands,
+    IngestSnapshot,
+    ApplySnapshot,
+    InterpolateNetEntities,
+    InterpolateRemotePlayers,
+    SessionRetryInput,
+    SessionLifecycle,
+    SyncConnectionUi,
+}
 
 impl Plugin for NetworkingPlugin {
     fn build(&self, app: &mut App) {
         app.add_message::<NetworkCommand>()
+            .add_message::<SessionUiCommand>()
             .init_resource::<NetworkState>()
             .init_resource::<GameStateSnapshot>()
+            .init_resource::<PendingServerSnapshotFrame>()
+            .init_resource::<ClientSession>()
+            .init_resource::<NetIncomingDisconnected>()
             .insert_resource(LocalStateSendTimer(Timer::from_seconds(
                 UPDATE_INTERVAL_SECONDS,
                 TimerMode::Repeating,
             )))
-            .add_systems(Startup, (setup_network_visual_assets, start_networking))
             .add_systems(
+                Startup,
+                (
+                    setup_network_visual_assets,
+                    start_networking.after(crate::persistence::load_persistent_client_settings),
+                    setup_connection_status_ui,
+                ),
+            )
+            .configure_sets(
                 Update,
                 (
-                    send_local_state,
-                    send_network_commands,
-                    apply_server_snapshot,
+                    ClientNetPipeline::SendCommands.after(ClientNetPipeline::SendLocalState),
+                    ClientNetPipeline::IngestSnapshot.after(ClientNetPipeline::SendCommands),
+                    ClientNetPipeline::ApplySnapshot.after(ClientNetPipeline::IngestSnapshot),
+                    ClientNetPipeline::InterpolateNetEntities
+                        .after(ClientNetPipeline::ApplySnapshot),
+                    ClientNetPipeline::InterpolateRemotePlayers
+                        .after(ClientNetPipeline::InterpolateNetEntities),
+                    ClientNetPipeline::SessionRetryInput
+                        .after(ClientNetPipeline::InterpolateRemotePlayers),
+                    ClientNetPipeline::SessionLifecycle.after(ClientNetPipeline::SessionRetryInput),
+                    ClientNetPipeline::SyncConnectionUi.after(ClientNetPipeline::SessionLifecycle),
                 ),
             )
             .add_systems(
                 Update,
-                interpolate_snapshot_entities.after(apply_server_snapshot),
+                send_local_state.in_set(ClientNetPipeline::SendLocalState),
             )
             .add_systems(
                 Update,
-                interpolate_remote_players.after(apply_server_snapshot),
+                send_network_commands.in_set(ClientNetPipeline::SendCommands),
+            )
+            .add_systems(
+                Update,
+                ingest_server_snapshot_packets.in_set(ClientNetPipeline::IngestSnapshot),
+            )
+            .add_systems(
+                Update,
+                apply_server_snapshot.in_set(ClientNetPipeline::ApplySnapshot),
+            )
+            .add_systems(
+                Update,
+                interpolate_snapshot_entities.in_set(ClientNetPipeline::InterpolateNetEntities),
+            )
+            .add_systems(
+                Update,
+                interpolate_remote_players.in_set(ClientNetPipeline::InterpolateRemotePlayers),
+            )
+            .add_systems(
+                Update,
+                handle_connection_retry_button.in_set(ClientNetPipeline::SessionRetryInput),
+            )
+            .add_systems(
+                Update,
+                update_session_lifecycle.in_set(ClientNetPipeline::SessionLifecycle),
+            )
+            .add_systems(
+                Update,
+                sync_connection_status_ui.in_set(ClientNetPipeline::SyncConnectionUi),
             );
     }
 }
 
 #[derive(Message, Clone, Copy, Debug)]
 pub enum NetworkCommand {
-    Cast { target: TargetId },
-    Join { team: Team, character: CharacterChoice },
+    Cast {
+        target: TargetId,
+    },
+    Join {
+        team: Team,
+        character: CharacterChoice,
+    },
     #[allow(dead_code)]
     RequestRematch,
 }
@@ -272,7 +408,9 @@ pub enum GameState {
     #[default]
     Lobby,
     Running,
-    Victory { winner: Team },
+    Victory {
+        winner: Team,
+    },
 }
 
 #[derive(Resource, Default, Clone)]
@@ -285,6 +423,7 @@ pub struct GameStateSnapshot {
 struct NetworkChannels {
     outgoing: Sender<ClientPacket>,
     incoming: Receiver<ServerPacket>,
+    signals: Receiver<NetThreadSignal>,
 }
 
 #[derive(Resource, Default)]
@@ -296,6 +435,26 @@ struct NetworkState {
     structures: HashMap<u64, Entity>,
     minions: HashMap<u64, Entity>,
     neutrals: HashMap<u64, Entity>,
+}
+
+/// Latest drained snapshot for this frame (filled by [`ingest_server_snapshot_packets`]).
+#[derive(Resource, Default)]
+struct PendingServerSnapshotFrame {
+    frame: Option<PendingSnapshotData>,
+}
+
+struct PendingSnapshotData {
+    wall_time: Instant,
+    your_id: u64,
+    players: Vec<PlayerState>,
+    projectiles: Vec<ProjectileState>,
+    structures: Vec<StructureState>,
+    minions: Vec<MinionState>,
+    neutrals: Vec<NeutralState>,
+    game_state: GameState,
+    rematch_in_secs: Option<u64>,
+    /// Local team choice at ingest time (spawn gate when server has not yet mirrored selection).
+    selected_team_for_spawn: Option<Team>,
 }
 
 #[derive(Resource)]
@@ -445,19 +604,57 @@ fn setup_network_visual_assets(
     });
 }
 
-fn start_networking(mut commands: Commands) {
-    let server_addr =
-        std::env::var("GAME_SERVER_ADDR").unwrap_or_else(|_| DEFAULT_SERVER_ADDR.to_owned());
+fn start_networking(
+    mut commands: Commands,
+    mut client_session: ResMut<ClientSession>,
+    file_addr: Res<FileGameServerAddr>,
+) {
+    let preferred_addr = std::env::var("GAME_SERVER_ADDR")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| file_addr.0.clone())
+        .unwrap_or_else(|| DEFAULT_GAME_SERVER_ADDR.to_owned());
+    let server_addr = validated_server_addr_or_default(&preferred_addr);
+    if server_addr != preferred_addr {
+        warn!(
+            "Ignoring invalid GAME_SERVER_ADDR/file value {preferred_addr:?}; falling back to {server_addr}"
+        );
+    }
+    spawn_network_transport(&mut commands, &mut client_session, server_addr);
+}
+
+fn validated_server_addr_or_default(raw: &str) -> String {
+    crate::persistence::validate_game_server_addr(raw)
+        .or_else(|| crate::persistence::validate_game_server_addr(DEFAULT_GAME_SERVER_ADDR))
+        .expect("default game server address must validate")
+}
+
+fn spawn_network_transport(
+    commands: &mut Commands,
+    client_session: &mut ClientSession,
+    server_addr: String,
+) {
+    client_session.server_addr_display.clone_from(&server_addr);
+    commands.insert_resource(ResolvedServerAddressForPrefs(server_addr.clone()));
     let (outgoing_tx, outgoing_rx) = unbounded::<ClientPacket>();
     let (incoming_tx, incoming_rx) = unbounded::<ServerPacket>();
+    let (signal_tx, signal_rx) = unbounded::<NetThreadSignal>();
 
+    let addr_for_thread = server_addr;
     thread::spawn(move || {
-        run_udp_client(server_addr, outgoing_rx, incoming_tx);
+        run_udp_client(addr_for_thread, outgoing_rx, incoming_tx, signal_tx);
     });
+
+    client_session.state = ClientConnectionState::WaitingForServer;
+    client_session.waiting_since = Some(Instant::now());
+    client_session.discard_incoming_snapshots = false;
+    client_session.join_flow_committed = false;
+    client_session.last_qualifying_snapshot_wall = None;
 
     commands.insert_resource(NetworkChannels {
         outgoing: outgoing_tx,
         incoming: incoming_rx,
+        signals: signal_rx,
     });
 }
 
@@ -465,22 +662,26 @@ fn run_udp_client(
     server_addr: String,
     outgoing: Receiver<ClientPacket>,
     incoming: Sender<ServerPacket>,
+    signals: Sender<NetThreadSignal>,
 ) {
     println!("Connecting to server at {server_addr}");
     let socket = match UdpSocket::bind(LOCAL_BIND_ADDR) {
         Ok(socket) => socket,
         Err(error) => {
             eprintln!("Failed to bind client UDP socket: {error}");
+            let _ = signals.send(NetThreadSignal::TransportFailure);
             return;
         }
     };
 
     if let Err(error) = socket.connect(&server_addr) {
         eprintln!("Failed to connect UDP socket to {server_addr}: {error}");
+        let _ = signals.send(NetThreadSignal::TransportFailure);
         return;
     }
     if let Err(error) = socket.set_nonblocking(true) {
         eprintln!("Failed to set UDP client socket nonblocking: {error}");
+        let _ = signals.send(NetThreadSignal::TransportFailure);
         return;
     }
     println!("UDP socket connected to {server_addr}; waiting for first snapshot");
@@ -489,51 +690,80 @@ fn run_udp_client(
     let mut last_heartbeat_at = Instant::now();
     let mut last_receive_error_log_at: Option<Instant> = None;
     let mut first_snapshot_received = false;
+    let mut consecutive_recv_errors: u32 = 0;
+    let mut consecutive_send_errors: u32 = 0;
+    let mut transport_failure_reported = false;
 
-    let _ = send_packet(&socket, &ClientPacket::Ping);
+    let _ = udp_try_send(
+        &socket,
+        &ClientPacket::Ping,
+        &mut consecutive_send_errors,
+        &mut transport_failure_reported,
+        &signals,
+    );
 
     loop {
         loop {
             match outgoing.try_recv() {
                 Ok(packet) => {
-                    if send_packet(&socket, &packet).is_err() {
-                        eprintln!("Failed to send packet to server");
-                    }
+                    udp_try_send(
+                        &socket,
+                        &packet,
+                        &mut consecutive_send_errors,
+                        &mut transport_failure_reported,
+                        &signals,
+                    );
                 }
                 Err(TryRecvError::Empty) => break,
                 Err(TryRecvError::Disconnected) => return,
             }
         }
 
-        if last_heartbeat_at.elapsed() >= HEARTBEAT_INTERVAL {
-            let _ = send_packet(&socket, &ClientPacket::Ping);
+        if last_heartbeat_at.elapsed() >= T_RETRY {
+            udp_try_send(
+                &socket,
+                &ClientPacket::Ping,
+                &mut consecutive_send_errors,
+                &mut transport_failure_reported,
+                &signals,
+            );
             last_heartbeat_at = Instant::now();
         }
 
         loop {
             match socket.recv(&mut recv_buf) {
-                Ok(len) => match serde_json::from_slice::<ServerPacket>(&recv_buf[..len]) {
-                    Ok(packet) => {
-                        if !first_snapshot_received {
-                            println!(
-                                "First snapshot received from {server_addr}; connection is live"
-                            );
-                            first_snapshot_received = true;
+                Ok(len) => {
+                    consecutive_recv_errors = 0;
+                    match serde_json::from_slice::<ServerPacket>(&recv_buf[..len]) {
+                        Ok(packet) => {
+                            if !first_snapshot_received {
+                                println!(
+                                    "First snapshot received from {server_addr}; connection is live"
+                                );
+                                first_snapshot_received = true;
+                            }
+                            let _ = incoming.send(packet);
                         }
-                        let _ = incoming.send(packet);
+                        Err(error) => {
+                            eprintln!("Failed to decode server packet: {error}");
+                        }
                     }
-                    Err(error) => {
-                        eprintln!("Failed to decode server packet: {error}");
-                    }
-                },
+                }
                 Err(error) if error.kind() == io::ErrorKind::WouldBlock => break,
                 Err(error) => {
+                    consecutive_recv_errors = consecutive_recv_errors.saturating_add(1);
                     let now = Instant::now();
                     if last_receive_error_log_at
                         .is_none_or(|last| now.duration_since(last) >= Duration::from_secs(1))
                     {
                         eprintln!("Client socket receive error: {error}");
                         last_receive_error_log_at = Some(now);
+                    }
+                    if consecutive_recv_errors >= TRANSPORT_CONSECUTIVE_RECV_ERRORS
+                        && !transport_failure_reported
+                    {
+                        transport_failure_reported = true;
+                        let _ = signals.send(NetThreadSignal::TransportFailure);
                     }
                     break;
                 }
@@ -551,15 +781,46 @@ fn send_packet(socket: &UdpSocket, packet: &ClientPacket) -> io::Result<()> {
     Ok(())
 }
 
+fn udp_try_send(
+    socket: &UdpSocket,
+    packet: &ClientPacket,
+    consecutive_send_errors: &mut u32,
+    transport_failure_reported: &mut bool,
+    signals: &Sender<NetThreadSignal>,
+) -> bool {
+    match send_packet(socket, packet) {
+        Ok(()) => {
+            *consecutive_send_errors = 0;
+            true
+        }
+        Err(error) => {
+            *consecutive_send_errors = consecutive_send_errors.saturating_add(1);
+            eprintln!("Client UDP send error: {error}");
+            if *consecutive_send_errors >= TRANSPORT_CONSECUTIVE_SEND_ERRORS
+                && !*transport_failure_reported
+            {
+                *transport_failure_reported = true;
+                let _ = signals.send(NetThreadSignal::TransportFailure);
+            }
+            false
+        }
+    }
+}
+
 fn send_local_state(
     time: Res<Time>,
     mut timer: ResMut<LocalStateSendTimer>,
     channels: Option<Res<NetworkChannels>>,
+    client_session: Res<ClientSession>,
     player_query: Query<&Transform, With<Player>>,
 ) {
     let Some(channels) = channels else {
         return;
     };
+
+    if !client_session.is_connected() {
+        return;
+    }
 
     timer.0.tick(time.delta());
     if !timer.0.just_finished() {
@@ -583,6 +844,7 @@ fn send_local_state(
 fn send_network_commands(
     mut command_events: MessageReader<NetworkCommand>,
     channels: Option<Res<NetworkChannels>>,
+    mut client_session: ResMut<ClientSession>,
 ) {
     let Some(channels) = channels else {
         return;
@@ -591,17 +853,27 @@ fn send_network_commands(
     for command in command_events.read() {
         match command {
             NetworkCommand::Cast { target } => {
+                if !client_session.is_connected() {
+                    continue;
+                }
                 let _ = channels
                     .outgoing
                     .send(ClientPacket::Cast { target: *target });
             }
             NetworkCommand::Join { team, character } => {
+                if client_session.join_flow_committed {
+                    continue;
+                }
+                client_session.join_flow_committed = true;
                 let _ = channels.outgoing.send(ClientPacket::Join {
                     team: *team,
                     character: *character,
                 });
             }
             NetworkCommand::RequestRematch => {
+                if !client_session.is_connected() {
+                    continue;
+                }
                 let _ = channels.outgoing.send(ClientPacket::RequestRematch);
             }
         }
@@ -622,9 +894,104 @@ fn choose_authoritative_local_player<T: Copy + Eq>(
     chosen
 }
 
+fn ingest_server_snapshot_packets(
+    channels: Option<Res<NetworkChannels>>,
+    client_session: Res<ClientSession>,
+    mut pending: ResMut<PendingServerSnapshotFrame>,
+    mut incoming_dead: ResMut<NetIncomingDisconnected>,
+    team_selection: Res<TeamSelection>,
+) {
+    pending.frame = None;
+    let Some(channels) = channels.as_ref() else {
+        return;
+    };
+
+    if client_session.discard_incoming_snapshots {
+        loop {
+            match channels.incoming.try_recv() {
+                Ok(_) => {}
+                Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => break,
+            }
+        }
+        return;
+    }
+
+    let mut latest_snapshot: Option<(
+        u64,
+        Vec<PlayerState>,
+        Vec<ProjectileState>,
+        Vec<StructureState>,
+        Vec<MinionState>,
+        Vec<NeutralState>,
+        GameState,
+        Option<u64>,
+    )> = None;
+
+    loop {
+        match channels.incoming.try_recv() {
+            Err(TryRecvError::Empty) => break,
+            Err(TryRecvError::Disconnected) => {
+                incoming_dead.0 = true;
+                break;
+            }
+            Ok(packet) => match packet {
+                ServerPacket::Snapshot {
+                    your_id,
+                    players,
+                    projectiles,
+                    structures,
+                    minions,
+                    neutrals,
+                    game_state,
+                    rematch_in_secs,
+                } => {
+                    latest_snapshot = Some((
+                        your_id,
+                        players,
+                        projectiles,
+                        structures,
+                        minions,
+                        neutrals,
+                        game_state,
+                        rematch_in_secs,
+                    ));
+                }
+            },
+        }
+    }
+
+    let Some((
+        your_id,
+        players,
+        projectiles,
+        structures,
+        minions,
+        neutrals,
+        game_state,
+        rematch_in_secs,
+    )) = latest_snapshot
+    else {
+        return;
+    };
+
+    pending.frame = Some(PendingSnapshotData {
+        wall_time: Instant::now(),
+        your_id,
+        players,
+        projectiles,
+        structures,
+        minions,
+        neutrals,
+        game_state,
+        rematch_in_secs,
+        selected_team_for_spawn: team_selection.team,
+    });
+}
+
 fn apply_server_snapshot(
     mut commands: Commands,
-    channels: Option<Res<NetworkChannels>>,
+    mut pending: ResMut<PendingServerSnapshotFrame>,
+    mut client_session: ResMut<ClientSession>,
     mut network_state: ResMut<NetworkState>,
     mut transform_sets: ParamSet<(
         Query<&mut Transform>,
@@ -641,49 +1008,12 @@ fn apply_server_snapshot(
     visuals: Res<NetworkVisualAssets>,
     mut game_state_snapshot: ResMut<GameStateSnapshot>,
     mut cam_state: ResMut<CameraState>,
-    team_selection: Res<TeamSelection>,
 ) {
-    let Some(channels) = channels else {
+    let Some(data) = pending.frame.take() else {
         return;
     };
-
-    let mut latest_snapshot: Option<(
-        u64,
-        Vec<PlayerState>,
-        Vec<ProjectileState>,
-        Vec<StructureState>,
-        Vec<MinionState>,
-        Vec<NeutralState>,
-        GameState,
-        Option<u64>,
-    )> = None;
-    while let Ok(packet) = channels.incoming.try_recv() {
-        match packet {
-            ServerPacket::Snapshot {
-                your_id,
-                players,
-                projectiles,
-                structures,
-                minions,
-                neutrals,
-                game_state,
-                rematch_in_secs,
-            } => {
-                latest_snapshot = Some((
-                    your_id,
-                    players,
-                    projectiles,
-                    structures,
-                    minions,
-                    neutrals,
-                    game_state,
-                    rematch_in_secs,
-                ));
-            }
-        }
-    }
-
-    let Some((
+    let PendingSnapshotData {
+        wall_time: snapshot_wall_time,
         your_id,
         players,
         projectiles,
@@ -692,11 +1022,14 @@ fn apply_server_snapshot(
         neutrals,
         game_state,
         rematch_in_secs,
-    )) =
-        latest_snapshot
-    else {
-        return;
-    };
+        selected_team_for_spawn,
+    } = data;
+
+    if client_session.state != ClientConnectionState::Connected {
+        client_session.state = ClientConnectionState::Connected;
+        client_session.waiting_since = None;
+    }
+    client_session.last_qualifying_snapshot_wall = Some(snapshot_wall_time);
 
     network_state.local_id = Some(your_id);
     game_state_snapshot.state = game_state;
@@ -709,8 +1042,7 @@ fn apply_server_snapshot(
         .collect::<Vec<_>>();
     // IMPORTANT: we must tolerate temporary duplication of `Player` entities (e.g. during loading /
     // restart races). Many gameplay systems use `Query::single()` and will break if we allow >1.
-    let chosen_local =
-        choose_authoritative_local_player(&local_players, your_id);
+    let chosen_local = choose_authoritative_local_player(&local_players, your_id);
 
     if let Some(local_entity) = chosen_local {
         // Keep exactly one local `Player` alive to avoid `single()` query failures.
@@ -763,7 +1095,7 @@ fn apply_server_snapshot(
         }
     } else if let Some(local_player_state) = local_player_state {
         // Wait for server ack of selected team to avoid first spawn on default Green.
-        let Some(selected_team) = team_selection.team else {
+        let Some(selected_team) = selected_team_for_spawn else {
             return;
         };
         if local_player_state.team != selected_team {
@@ -1209,6 +1541,372 @@ fn interpolate_remote_players(
         transform.rotation = interpolation
             .from_rotation
             .slerp(interpolation.to_rotation, t);
+    }
+}
+
+#[derive(Component)]
+struct ConnectionStatusRoot;
+
+#[derive(Component)]
+struct ConnectionStatusLabel;
+
+#[derive(Component)]
+struct ConnectionRetryButton;
+
+const CONNECTION_PANEL_BG: Color = Color::srgba(0.02, 0.02, 0.06, 0.72);
+
+fn setup_connection_status_ui(mut commands: Commands) {
+    commands
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                left: Val::Px(16.0),
+                top: Val::Px(12.0),
+                padding: UiRect::all(Val::Px(12.0)),
+                flex_direction: FlexDirection::Column,
+                row_gap: Val::Px(8.0),
+                ..default()
+            },
+            BackgroundColor(CONNECTION_PANEL_BG),
+            ConnectionStatusRoot,
+            Visibility::Visible,
+            ZIndex(20),
+            Name::new("ConnectionStatusPanel"),
+        ))
+        .with_children(|parent| {
+            parent.spawn((
+                Text::new(""),
+                TextFont {
+                    font_size: 16.0,
+                    ..default()
+                },
+                TextColor(Color::WHITE),
+                ConnectionStatusLabel,
+            ));
+            parent
+                .spawn((
+                    Button,
+                    Node {
+                        width: Val::Px(120.0),
+                        height: Val::Px(36.0),
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    BackgroundColor(Color::srgb(0.25, 0.42, 0.32)),
+                    Visibility::Hidden,
+                    ConnectionRetryButton,
+                ))
+                .with_children(|button| {
+                    button.spawn((
+                        Text::new("Retry"),
+                        TextFont {
+                            font_size: 16.0,
+                            ..default()
+                        },
+                        TextColor(Color::WHITE),
+                    ));
+                });
+        });
+}
+
+fn handle_connection_retry_button(
+    interaction: Query<&Interaction, (With<ConnectionRetryButton>, Changed<Interaction>)>,
+    mut writer: MessageWriter<SessionUiCommand>,
+) {
+    for i in &interaction {
+        if *i == Interaction::Pressed {
+            writer.write(SessionUiCommand::Retry);
+        }
+    }
+}
+
+fn sync_connection_status_ui(
+    client_session: Res<ClientSession>,
+    mut label_q: Query<&mut Text, With<ConnectionStatusLabel>>,
+    mut retry_vis: Query<&mut Visibility, With<ConnectionRetryButton>>,
+) {
+    let Ok(mut text) = label_q.single_mut() else {
+        return;
+    };
+    match client_session.state {
+        ClientConnectionState::Connecting => {
+            text.0 = format!("Connecting… ({})", client_session.server_addr_display);
+        }
+        ClientConnectionState::WaitingForServer => {
+            text.0 = format!(
+                "Waiting for server at {}. Start the server or check GAME_SERVER_ADDR. Retries every {}s (max wait {}s).",
+                client_session.server_addr_display,
+                T_RETRY.as_secs(),
+                T_WAIT_MAX.as_secs()
+            );
+        }
+        ClientConnectionState::Connected => {
+            text.0 = format!("Connected ({}).", client_session.server_addr_display);
+        }
+        ClientConnectionState::Disconnected => {
+            text.0 = "Disconnected — connection lost or timed out. Use Retry when the server is back, then choose your team again."
+                .to_string();
+        }
+    }
+
+    let Ok(mut retry_vis) = retry_vis.single_mut() else {
+        return;
+    };
+    *retry_vis = if client_session.state == ClientConnectionState::Disconnected {
+        Visibility::Visible
+    } else {
+        Visibility::Hidden
+    };
+}
+
+fn despawn_tracked_net_entities(
+    commands: &mut Commands,
+    network_state: &mut NetworkState,
+    remote_query: &Query<Entity, With<RemotePlayer>>,
+    projectile_query: &Query<Entity, With<NetworkProjectile>>,
+    structure_query: &Query<Entity, With<NetworkStructure>>,
+    minion_query: &Query<Entity, With<NetworkMinion>>,
+    neutral_query: &Query<Entity, With<NetworkNeutral>>,
+) {
+    for &entity in network_state.remote_players.values() {
+        if remote_query.get(entity).is_ok() {
+            commands
+                .entity(entity)
+                .despawn_related::<Children>()
+                .despawn();
+        }
+    }
+    network_state.remote_players.clear();
+
+    for &entity in network_state.projectiles.values() {
+        if projectile_query.get(entity).is_ok() {
+            commands
+                .entity(entity)
+                .despawn_related::<Children>()
+                .despawn();
+        }
+    }
+    network_state.projectiles.clear();
+
+    for &entity in network_state.structures.values() {
+        if structure_query.get(entity).is_ok() {
+            commands
+                .entity(entity)
+                .despawn_related::<Children>()
+                .despawn();
+        }
+    }
+    network_state.structures.clear();
+
+    for &entity in network_state.minions.values() {
+        if minion_query.get(entity).is_ok() {
+            commands
+                .entity(entity)
+                .despawn_related::<Children>()
+                .despawn();
+        }
+    }
+    network_state.minions.clear();
+
+    for &entity in network_state.neutrals.values() {
+        if neutral_query.get(entity).is_ok() {
+            commands
+                .entity(entity)
+                .despawn_related::<Children>()
+                .despawn();
+        }
+    }
+    network_state.neutrals.clear();
+
+    network_state.local_id = None;
+    network_state.local_team = None;
+}
+
+fn despawn_local_players(commands: &mut Commands, player_query: &Query<Entity, With<Player>>) {
+    for entity in player_query.iter() {
+        commands
+            .entity(entity)
+            .despawn_related::<Children>()
+            .despawn();
+    }
+}
+
+fn perform_network_teardown(
+    commands: &mut Commands,
+    client_session: &mut ClientSession,
+    network_state: &mut NetworkState,
+    game_state_snapshot: &mut GameStateSnapshot,
+    team_selection: &mut TeamSelection,
+    cam_state: &mut CameraState,
+    overlay_query: &Query<Entity, With<TeamSelectRoot>>,
+    remote_query: &Query<Entity, With<RemotePlayer>>,
+    projectile_query: &Query<Entity, With<NetworkProjectile>>,
+    structure_query: &Query<Entity, With<NetworkStructure>>,
+    minion_query: &Query<Entity, With<NetworkMinion>>,
+    neutral_query: &Query<Entity, With<NetworkNeutral>>,
+    player_query: &Query<Entity, With<Player>>,
+) {
+    despawn_tracked_net_entities(
+        commands,
+        network_state,
+        remote_query,
+        projectile_query,
+        structure_query,
+        minion_query,
+        neutral_query,
+    );
+    despawn_local_players(commands, player_query);
+
+    *game_state_snapshot = GameStateSnapshot::default();
+    cam_state.locked = false;
+    team_selection.team = None;
+
+    if overlay_query.iter().next().is_none() {
+        spawn_team_select_ui(commands, team_selection.character);
+    }
+
+    client_session.state = ClientConnectionState::Disconnected;
+    client_session.discard_incoming_snapshots = true;
+    client_session.join_flow_committed = false;
+    client_session.waiting_since = None;
+    client_session.last_qualifying_snapshot_wall = None;
+}
+
+fn update_session_lifecycle(
+    mut commands: Commands,
+    mut client_session: ResMut<ClientSession>,
+    mut incoming_dead: ResMut<NetIncomingDisconnected>,
+    channels: Option<Res<NetworkChannels>>,
+    mut network_state: ResMut<NetworkState>,
+    mut game_state_snapshot: ResMut<GameStateSnapshot>,
+    mut team_selection: ResMut<TeamSelection>,
+    mut cam_state: ResMut<CameraState>,
+    overlay_query: Query<Entity, With<TeamSelectRoot>>,
+    mut session_ui: MessageReader<SessionUiCommand>,
+    remote_query: Query<Entity, With<RemotePlayer>>,
+    projectile_query: Query<Entity, With<NetworkProjectile>>,
+    structure_query: Query<Entity, With<NetworkStructure>>,
+    minion_query: Query<Entity, With<NetworkMinion>>,
+    neutral_query: Query<Entity, With<NetworkNeutral>>,
+    player_query: Query<Entity, With<Player>>,
+) {
+    let mut retried_this_frame = false;
+    for event in session_ui.read() {
+        match event {
+            SessionUiCommand::Retry => {
+                if client_session.state == ClientConnectionState::Disconnected {
+                    commands.remove_resource::<NetworkChannels>();
+                    let retry_addr =
+                        validated_server_addr_or_default(&client_session.server_addr_display);
+                    spawn_network_transport(&mut commands, &mut client_session, retry_addr);
+                    incoming_dead.0 = false;
+                    retried_this_frame = true;
+                }
+            }
+        }
+    }
+
+    // Ignore stale transport signals in the same frame as a Retry-triggered transport swap.
+    if retried_this_frame {
+        return;
+    }
+
+    let Some(channels) = channels.as_ref() else {
+        return;
+    };
+
+    if incoming_dead.0 {
+        incoming_dead.0 = false;
+        if client_session.state != ClientConnectionState::Disconnected {
+            perform_network_teardown(
+                &mut commands,
+                &mut client_session,
+                &mut network_state,
+                &mut game_state_snapshot,
+                &mut team_selection,
+                &mut cam_state,
+                &overlay_query,
+                &remote_query,
+                &projectile_query,
+                &structure_query,
+                &minion_query,
+                &neutral_query,
+                &player_query,
+            );
+        }
+    }
+
+    while let Ok(signal) = channels.signals.try_recv() {
+        match signal {
+            NetThreadSignal::TransportFailure => {
+                if client_session.state != ClientConnectionState::Disconnected {
+                    perform_network_teardown(
+                        &mut commands,
+                        &mut client_session,
+                        &mut network_state,
+                        &mut game_state_snapshot,
+                        &mut team_selection,
+                        &mut cam_state,
+                        &overlay_query,
+                        &remote_query,
+                        &projectile_query,
+                        &structure_query,
+                        &minion_query,
+                        &neutral_query,
+                        &player_query,
+                    );
+                }
+            }
+        }
+    }
+
+    let now = Instant::now();
+
+    if client_session.state == ClientConnectionState::WaitingForServer {
+        if let Some(since) = client_session.waiting_since {
+            if since.elapsed() >= T_WAIT_MAX {
+                perform_network_teardown(
+                    &mut commands,
+                    &mut client_session,
+                    &mut network_state,
+                    &mut game_state_snapshot,
+                    &mut team_selection,
+                    &mut cam_state,
+                    &overlay_query,
+                    &remote_query,
+                    &projectile_query,
+                    &structure_query,
+                    &minion_query,
+                    &neutral_query,
+                    &player_query,
+                );
+            }
+        }
+    }
+
+    if client_session.state == ClientConnectionState::Connected {
+        if is_stale(
+            client_session.last_qualifying_snapshot_wall,
+            now,
+            T_STALE_SNAPSHOT,
+        ) {
+            perform_network_teardown(
+                &mut commands,
+                &mut client_session,
+                &mut network_state,
+                &mut game_state_snapshot,
+                &mut team_selection,
+                &mut cam_state,
+                &overlay_query,
+                &remote_query,
+                &projectile_query,
+                &structure_query,
+                &minion_query,
+                &neutral_query,
+                &player_query,
+            );
+        }
     }
 }
 

--- a/client/src/pause_menu.rs
+++ b/client/src/pause_menu.rs
@@ -4,7 +4,12 @@ use bevy::{
     window::{CursorGrabMode, CursorOptions, PrimaryWindow},
 };
 
+use crate::net::{ClientConnectionState, ClientSession};
+use crate::persistence::{
+    ClientPrefsSaveGate, ResolvedServerAddressForPrefs, reset_graphics_to_defaults,
+};
 use crate::player::Player;
+use crate::session_config::DEFAULT_GAME_SERVER_ADDR;
 use crate::team::{TeamSelectRoot, TeamSelection, spawn_team_select_ui};
 use crate::world::{
     DEFAULT_AMBIENT_BRIGHTNESS, DEFAULT_LIGHT_ILLUMINANCE, DEFAULT_LIGHT_PITCH_DEG,
@@ -38,6 +43,7 @@ impl Plugin for PauseMenuPlugin {
                 Update,
                 (
                     toggle_pause_menu,
+                    close_pause_menu_when_disconnected,
                     handle_settings_navigation_buttons,
                     sync_pause_menu_visibility,
                     sync_pause_menu_sections,
@@ -46,7 +52,9 @@ impl Plugin for PauseMenuPlugin {
                     update_model_scale_label,
                     update_lighting_labels,
                     handle_restart_button_request,
+                    handle_reset_graphics_defaults_button,
                     handle_exit_button,
+                    sync_settings_server_addr_label,
                 ),
             )
             .add_systems(Last, process_restart_request);
@@ -78,6 +86,9 @@ struct SettingsOpenButton;
 
 #[derive(Component)]
 struct SettingsBackButton;
+
+#[derive(Component)]
+struct ResetGraphicsDefaultsButton;
 
 #[derive(Component)]
 struct ExitButton;
@@ -129,6 +140,9 @@ struct PitchValueLabel;
 
 #[derive(Component)]
 struct YawValueLabel;
+
+#[derive(Component)]
+struct SettingsServerAddrLabel;
 
 fn setup_pause_menu_ui(mut commands: Commands) {
     commands
@@ -242,6 +256,17 @@ fn setup_pause_menu_ui(mut commands: Commands) {
                             ));
 
                             settings.spawn((
+                                Text::new(""),
+                                TextFont {
+                                    font_size: 14.0,
+                                    ..default()
+                                },
+                                TextColor(Color::srgb(0.75, 0.78, 0.85)),
+                                SettingsServerAddrLabel,
+                                Name::new("PauseMenuServerAddrHint"),
+                            ));
+
+                            settings.spawn((
                                 Text::new("Lighting"),
                                 TextFont {
                                     font_size: 18.0,
@@ -309,6 +334,13 @@ fn setup_pause_menu_ui(mut commands: Commands) {
                                 ScaleValueLabel,
                                 ScaleIncreaseButton,
                                 "PauseMenuScaleControls",
+                            );
+
+                            spawn_menu_button(
+                                settings,
+                                "Reset graphics to defaults",
+                                ResetGraphicsDefaultsButton,
+                                "PauseMenuResetGraphicsButton",
                             );
 
                             spawn_menu_button(settings, "Back", SettingsBackButton, "BackButton");
@@ -438,6 +470,20 @@ fn spawn_adjust_row<Dec: Component, ValueMarker: Component, Inc: Component>(
                 ));
             });
         });
+}
+
+/// Match-assuming UI must not stay open without an active session (TASK-14 P5 / AC6).
+fn close_pause_menu_when_disconnected(
+    client_session: Res<ClientSession>,
+    mut menu_state: ResMut<PauseMenuState>,
+) {
+    if client_session.state != ClientConnectionState::Disconnected {
+        return;
+    }
+    if menu_state.open {
+        menu_state.open = false;
+        menu_state.in_settings = false;
+    }
 }
 
 fn toggle_pause_menu(
@@ -720,6 +766,76 @@ fn update_lighting_labels(
     }
     if let Ok(mut text) = label_queries.p3().single_mut() {
         text.0 = format!("{:.0}°", lighting_settings.light_yaw_deg);
+    }
+}
+
+fn sync_settings_server_addr_label(
+    resolved_addr: Res<ResolvedServerAddressForPrefs>,
+    mut label_q: Query<&mut Text, With<SettingsServerAddrLabel>>,
+) {
+    let addr = {
+        let s = resolved_addr.0.as_str().trim();
+        if s.is_empty() {
+            DEFAULT_GAME_SERVER_ADDR
+        } else {
+            s
+        }
+    };
+    let next = format!(
+        "Game server: {addr}\n\
+         Saved with preferences when you change graphics or character. \
+         Next launch: set GAME_SERVER_ADDR or edit client_preferences.json (see persistence docs)."
+    );
+    if let Ok(mut text) = label_q.single_mut() {
+        if text.0 != next {
+            text.0 = next;
+        }
+    }
+}
+
+fn handle_reset_graphics_defaults_button(
+    mut lighting: ResMut<LightingSettings>,
+    mut model: ResMut<ModelScaleSettings>,
+    mut prefs_gate: ResMut<ClientPrefsSaveGate>,
+    resolved_addr: Res<ResolvedServerAddressForPrefs>,
+    team: Res<TeamSelection>,
+    mut button_query: Query<
+        (&Interaction, &mut BackgroundColor),
+        (
+            Changed<Interaction>,
+            With<Button>,
+            With<ResetGraphicsDefaultsButton>,
+        ),
+    >,
+) {
+    let addr = {
+        let s = resolved_addr.0.as_str().trim();
+        if s.is_empty() {
+            DEFAULT_GAME_SERVER_ADDR
+        } else {
+            s
+        }
+    };
+
+    for (interaction, mut color) in &mut button_query {
+        match *interaction {
+            Interaction::Pressed => {
+                reset_graphics_to_defaults(
+                    lighting.as_mut(),
+                    model.as_mut(),
+                    prefs_gate.as_mut(),
+                    team.character,
+                    addr,
+                );
+                *color = BUTTON_HOVER_COLOR.into();
+            }
+            Interaction::Hovered => {
+                *color = BUTTON_HOVER_COLOR.into();
+            }
+            Interaction::None => {
+                *color = BUTTON_COLOR.into();
+            }
+        }
     }
 }
 

--- a/client/src/persistence.rs
+++ b/client/src/persistence.rs
@@ -1,0 +1,360 @@
+//! On-disk client preferences: graphics, character selection, optional server address.
+//!
+//! **Load path**: `OMOBA_CLIENT_CONFIG_DIR` if set, else platform default
+//! (`~/.config/omoba-bevy/client_preferences.json` on Unix,
+//! `%APPDATA%/omoba-bevy/client_preferences.json` on Windows).
+//!
+//! **Server address precedence** matches [`crate::session_config`] docs.
+
+use std::fs;
+use std::io;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+
+use bevy::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::session_config::DEFAULT_GAME_SERVER_ADDR;
+use crate::team::CharacterChoice;
+use crate::world::{
+    LightingSettings, MAX_AMBIENT_BRIGHTNESS, MAX_LIGHT_ILLUMINANCE, MAX_LIGHT_PITCH_DEG,
+    MAX_LIGHT_YAW_DEG, MAX_MODEL_TARGET_HEIGHT, MIN_AMBIENT_BRIGHTNESS, MIN_LIGHT_ILLUMINANCE,
+    MIN_LIGHT_PITCH_DEG, MIN_LIGHT_YAW_DEG, MIN_MODEL_TARGET_HEIGHT, ModelScaleSettings,
+};
+
+const SCHEMA_VERSION: u32 = 1;
+const PREFS_FILENAME: &str = "client_preferences.json";
+
+/// Address loaded from disk for use when `GAME_SERVER_ADDR` is unset (validated).
+#[derive(Resource, Default, Clone)]
+pub struct FileGameServerAddr(pub Option<String>);
+
+/// Last address used for UDP (env, file, or default), for persisting alongside graphics prefs.
+#[derive(Resource, Default, Clone)]
+pub struct ResolvedServerAddressForPrefs(pub String);
+
+pub struct ClientPersistencePlugin;
+
+impl Plugin for ClientPersistencePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<FileGameServerAddr>()
+            .init_resource::<ResolvedServerAddressForPrefs>()
+            .init_resource::<ClientPrefsSaveGate>()
+            .add_systems(Startup, load_persistent_client_settings)
+            .add_systems(Update, save_client_preferences_on_change);
+    }
+}
+
+/// Prevents spurious saves during the first frames after startup.
+#[derive(Resource, Default)]
+pub struct ClientPrefsSaveGate {
+    pub suppress_saves: u8,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ClientPreferencesFile {
+    #[serde(default = "default_schema_version")]
+    schema_version: u32,
+    #[serde(default)]
+    game_server_addr: Option<String>,
+    #[serde(default)]
+    character: Option<CharacterChoice>,
+    #[serde(default)]
+    model_target_height: Option<f32>,
+    #[serde(default)]
+    illuminance: Option<f32>,
+    #[serde(default)]
+    ambient_brightness: Option<f32>,
+    #[serde(default)]
+    light_pitch_deg: Option<f32>,
+    #[serde(default)]
+    light_yaw_deg: Option<f32>,
+}
+
+fn default_schema_version() -> u32 {
+    SCHEMA_VERSION
+}
+
+fn preferences_path() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("OMOBA_CLIENT_CONFIG_DIR") {
+        let trimmed = dir.trim();
+        if !trimmed.is_empty() {
+            return Some(PathBuf::from(trimmed).join(PREFS_FILENAME));
+        }
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return std::env::var_os("APPDATA")
+            .map(|base| PathBuf::from(base).join("omoba-bevy").join(PREFS_FILENAME));
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        std::env::var_os("HOME").map(|h| {
+            PathBuf::from(h)
+                .join(".config")
+                .join("omoba-bevy")
+                .join(PREFS_FILENAME)
+        })
+    }
+}
+
+/// Validates `host:port` or a parseable [`SocketAddr`] string for client config.
+pub fn validate_game_server_addr(raw: &str) -> Option<String> {
+    let t = raw.trim();
+    if t.is_empty() {
+        return None;
+    }
+    if t.parse::<SocketAddr>().is_ok() {
+        return Some(t.to_string());
+    }
+    let (host, port_str) = t.rsplit_once(':')?;
+    let host = host.trim();
+    if host.is_empty() || host.contains([' ', '\t', '\n', '\r']) {
+        return None;
+    }
+    if host.len() > 253 {
+        return None;
+    }
+    let port: u16 = port_str.trim().parse().ok()?;
+    Some(format!("{host}:{port}"))
+}
+
+pub fn clamp_model_target_height(value: f32) -> f32 {
+    value.clamp(MIN_MODEL_TARGET_HEIGHT, MAX_MODEL_TARGET_HEIGHT)
+}
+
+pub fn clamp_lighting_settings(mut s: LightingSettings) -> LightingSettings {
+    s.illuminance = s
+        .illuminance
+        .clamp(MIN_LIGHT_ILLUMINANCE, MAX_LIGHT_ILLUMINANCE);
+    s.ambient_brightness = s
+        .ambient_brightness
+        .clamp(MIN_AMBIENT_BRIGHTNESS, MAX_AMBIENT_BRIGHTNESS);
+    s.light_pitch_deg = s
+        .light_pitch_deg
+        .clamp(MIN_LIGHT_PITCH_DEG, MAX_LIGHT_PITCH_DEG);
+    s.light_yaw_deg = s.light_yaw_deg.clamp(MIN_LIGHT_YAW_DEG, MAX_LIGHT_YAW_DEG);
+    s
+}
+
+fn read_preferences_file(path: &Path) -> io::Result<ClientPreferencesFile> {
+    let bytes = fs::read(path)?;
+    serde_json::from_slice(&bytes).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+fn write_preferences_file(path: &Path, prefs: &ClientPreferencesFile) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let data = serde_json::to_vec_pretty(prefs)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    fs::write(path, data)
+}
+
+/// Startup: load JSON if present and apply to resources; always sets [`FileGameServerAddr`].
+pub fn load_persistent_client_settings(
+    mut file_addr: ResMut<FileGameServerAddr>,
+    mut lighting: ResMut<LightingSettings>,
+    mut model: ResMut<ModelScaleSettings>,
+    mut team: ResMut<crate::team::TeamSelection>,
+    mut gate: ResMut<ClientPrefsSaveGate>,
+) {
+    gate.suppress_saves = 3;
+    file_addr.0 = None;
+
+    let Some(path) = preferences_path() else {
+        warn!("No home/config directory for client preferences; using defaults only.");
+        return;
+    };
+
+    if !path.exists() {
+        return;
+    }
+
+    let disk = match read_preferences_file(&path) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("Failed to read client preferences at {:?}: {e}", path);
+            return;
+        }
+    };
+
+    if disk.schema_version > SCHEMA_VERSION {
+        warn!(
+            "Client preferences schema {} is newer than supported {}; ignoring file {:?}",
+            disk.schema_version, SCHEMA_VERSION, path
+        );
+        return;
+    }
+
+    if let Some(addr_raw) = disk.game_server_addr.as_deref() {
+        if let Some(addr) = validate_game_server_addr(addr_raw) {
+            file_addr.0 = Some(addr);
+        } else {
+            warn!("Ignoring invalid game_server_addr in preferences file.");
+        }
+    }
+
+    if let Some(ch) = disk.character {
+        team.character = ch;
+    }
+
+    if let Some(h) = disk.model_target_height {
+        model.target_height = clamp_model_target_height(h);
+    }
+
+    if disk.illuminance.is_some()
+        || disk.ambient_brightness.is_some()
+        || disk.light_pitch_deg.is_some()
+        || disk.light_yaw_deg.is_some()
+    {
+        if let Some(v) = disk.illuminance {
+            lighting.illuminance = v;
+        }
+        if let Some(v) = disk.ambient_brightness {
+            lighting.ambient_brightness = v;
+        }
+        if let Some(v) = disk.light_pitch_deg {
+            lighting.light_pitch_deg = v;
+        }
+        if let Some(v) = disk.light_yaw_deg {
+            lighting.light_yaw_deg = v;
+        }
+        *lighting = clamp_lighting_settings(*lighting);
+    }
+}
+
+fn build_file_from_state(
+    lighting: &LightingSettings,
+    model: &ModelScaleSettings,
+    character: CharacterChoice,
+    game_server_addr: &str,
+) -> ClientPreferencesFile {
+    ClientPreferencesFile {
+        schema_version: SCHEMA_VERSION,
+        game_server_addr: Some(game_server_addr.to_string()),
+        character: Some(character),
+        model_target_height: Some(model.target_height),
+        illuminance: Some(lighting.illuminance),
+        ambient_brightness: Some(lighting.ambient_brightness),
+        light_pitch_deg: Some(lighting.light_pitch_deg),
+        light_yaw_deg: Some(lighting.light_yaw_deg),
+    }
+}
+
+/// Writes current resources to disk (graphics + character + active server display string).
+pub fn save_client_preferences_to_disk(
+    lighting: &LightingSettings,
+    model: &ModelScaleSettings,
+    character: CharacterChoice,
+    game_server_addr: &str,
+) -> io::Result<()> {
+    let Some(path) = preferences_path() else {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "no preferences path (set HOME/APPDATA or OMOBA_CLIENT_CONFIG_DIR)",
+        ));
+    };
+    let addr = validate_game_server_addr(game_server_addr).unwrap_or_else(|| {
+        validate_game_server_addr(DEFAULT_GAME_SERVER_ADDR)
+            .expect("default game server addr must validate")
+    });
+    let prefs = build_file_from_state(lighting, model, character, &addr);
+    write_preferences_file(&path, &prefs)
+}
+
+fn save_client_preferences_on_change(
+    mut gate: ResMut<ClientPrefsSaveGate>,
+    lighting: Res<LightingSettings>,
+    model: Res<ModelScaleSettings>,
+    team: Res<crate::team::TeamSelection>,
+    resolved_addr: Res<ResolvedServerAddressForPrefs>,
+) {
+    if gate.suppress_saves > 0 {
+        gate.suppress_saves -= 1;
+        return;
+    }
+
+    let changed = lighting.is_changed()
+        || model.is_changed()
+        || team.is_changed()
+        || resolved_addr.is_changed();
+    if !changed {
+        return;
+    }
+
+    let addr = resolved_addr.0.as_str();
+    if let Err(e) = save_client_preferences_to_disk(
+        lighting.as_ref(),
+        model.as_ref(),
+        team.character,
+        if addr.is_empty() {
+            DEFAULT_GAME_SERVER_ADDR
+        } else {
+            addr
+        },
+    ) {
+        warn!("Failed to save client preferences: {e}");
+    }
+}
+
+/// Resets graphics settings to defaults, persists, and re-opens save gate briefly.
+pub fn reset_graphics_to_defaults(
+    lighting: &mut LightingSettings,
+    model: &mut ModelScaleSettings,
+    gate: &mut ClientPrefsSaveGate,
+    character: CharacterChoice,
+    game_server_addr: &str,
+) {
+    *lighting = LightingSettings::default();
+    *model = ModelScaleSettings::default();
+    gate.suppress_saves = 1;
+    if let Err(e) = save_client_preferences_to_disk(lighting, model, character, game_server_addr) {
+        warn!("Failed to save preferences after reset: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_accepts_socket_addr() {
+        assert_eq!(
+            validate_game_server_addr("127.0.0.1:4000").as_deref(),
+            Some("127.0.0.1:4000")
+        );
+    }
+
+    #[test]
+    fn validate_accepts_host_port() {
+        assert_eq!(
+            validate_game_server_addr("localhost:5000").as_deref(),
+            Some("localhost:5000")
+        );
+    }
+
+    #[test]
+    fn validate_rejects_empty_and_garbage() {
+        assert!(validate_game_server_addr("").is_none());
+        assert!(validate_game_server_addr("   ").is_none());
+        assert!(validate_game_server_addr("nocolon").is_none());
+        assert!(validate_game_server_addr("host:").is_none());
+    }
+
+    #[test]
+    fn clamp_model_respects_bounds() {
+        assert_eq!(clamp_model_target_height(0.0), MIN_MODEL_TARGET_HEIGHT);
+        assert_eq!(clamp_model_target_height(99.0), MAX_MODEL_TARGET_HEIGHT);
+    }
+
+    #[test]
+    fn clamp_lighting_respects_bounds() {
+        let mut s = LightingSettings::default();
+        s.illuminance = 1.0;
+        s.ambient_brightness = 999_999.0;
+        let c = clamp_lighting_settings(s);
+        assert_eq!(c.illuminance, MIN_LIGHT_ILLUMINANCE);
+        assert_eq!(c.ambient_brightness, MAX_AMBIENT_BRIGHTNESS);
+    }
+}

--- a/client/src/session_config.rs
+++ b/client/src/session_config.rs
@@ -1,0 +1,82 @@
+//! Named timing thresholds for multiplayer session lifecycle (TASK-14).
+//! Values are tuned for local playtest; see `docs/network-client-session.md` and task spec.
+//!
+//! **Failure detection** (client): stale qualifying snapshot ([`T_STALE_SNAPSHOT`]), transport
+//! send/recv error streaks ([`TRANSPORT_CONSECUTIVE_SEND_ERRORS`],
+//! [`TRANSPORT_CONSECUTIVE_RECV_ERRORS`]), UDP thread signals ([`crate::net::NetThreadSignal`]),
+//! snapshot channel disconnect ([`crate::net::NetIncomingDisconnected`]), and bounded wait in
+//! **WaitingForServer** ([`T_WAIT_MAX`]).
+//!
+//! **Precedence for default server address** (see `persistence` + `net`):
+//! 1. Non-empty `GAME_SERVER_ADDR` environment variable
+//! 2. `game_server_addr` in the on-disk preferences file (if valid)
+//! 3. [`DEFAULT_GAME_SERVER_ADDR`]
+//!
+//! **Failure detection** (TASK-14): `net::update_session_lifecycle` tears down on stale snapshot
+//! (`is_stale` + [`T_STALE_SNAPSHOT`]), on `NetThreadSignal::TransportFailure` from the UDP thread
+//! (send/recv thresholds below), and on implicit loss if the network thread stops servicing the
+//! outgoing channel (`Disconnected`). See `RUNBOOK.md` for manual checks.
+
+use std::time::Duration;
+
+/// Default UDP server address when env and saved preferences do not supply one.
+pub const DEFAULT_GAME_SERVER_ADDR: &str = "127.0.0.1:4000";
+
+/// Outbound keepalive / retry interval while waiting for the first qualifying snapshot (P1).
+pub const T_RETRY: Duration = Duration::from_secs(2);
+
+/// Max wall time in **WaitingForServer** before moving to **Disconnected** with Retry (P1).
+pub const T_WAIT_MAX: Duration = Duration::from_secs(45);
+
+/// **Connected**: no qualifying snapshot for this continuous wall time ⇒ session loss (P3).
+pub const T_STALE_SNAPSHOT: Duration = Duration::from_secs(3);
+
+/// Consecutive UDP recv errors (excluding `WouldBlock`) before transport is treated as failed (P3).
+pub const TRANSPORT_CONSECUTIVE_RECV_ERRORS: u32 = 8;
+
+/// Consecutive UDP send failures before transport is treated as failed (P3).
+pub const TRANSPORT_CONSECUTIVE_SEND_ERRORS: u32 = 6;
+
+/// Returns true when `last` is missing or older than `limit` relative to `now`.
+pub fn is_stale(
+    last: Option<std::time::Instant>,
+    now: std::time::Instant,
+    limit: Duration,
+) -> bool {
+    last.is_none_or(|t| now.saturating_duration_since(t) >= limit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_stale_none_is_stale() {
+        let now = std::time::Instant::now();
+        assert!(is_stale(None, now, Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn is_stale_recent_not_stale() {
+        let now = std::time::Instant::now();
+        assert!(!is_stale(Some(now), now, Duration::from_secs(10)));
+    }
+
+    #[test]
+    fn is_stale_old_is_stale() {
+        let now = std::time::Instant::now();
+        let old = now.checked_sub(Duration::from_secs(10)).unwrap_or(now);
+        assert!(is_stale(Some(old), now, Duration::from_secs(3)));
+    }
+
+    /// Frozen TASK-14 policy: keep literals in this module only; tests lock expected playtest values.
+    #[test]
+    fn task_14_timing_constants_match_frozen_spec() {
+        assert_eq!(T_RETRY, Duration::from_secs(2));
+        assert_eq!(T_WAIT_MAX, Duration::from_secs(45));
+        assert_eq!(T_STALE_SNAPSHOT, Duration::from_secs(3));
+        assert_eq!(TRANSPORT_CONSECUTIVE_RECV_ERRORS, 8);
+        assert_eq!(TRANSPORT_CONSECUTIVE_SEND_ERRORS, 6);
+        assert_eq!(DEFAULT_GAME_SERVER_ADDR, "127.0.0.1:4000");
+    }
+}

--- a/client/src/team.rs
+++ b/client/src/team.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::net::NetworkCommand;
+use crate::net::{ClientSession, NetworkCommand};
 
 const TEAM_BUTTON_SIZE: f32 = 140.0;
 const TEAM_BUTTON_GAP: f32 = 28.0;
@@ -80,7 +80,10 @@ pub struct TeamSelectPlugin;
 impl Plugin for TeamSelectPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<TeamSelection>()
-            .add_systems(Startup, setup_team_select_ui)
+            .add_systems(
+                Startup,
+                setup_team_select_ui.after(crate::persistence::load_persistent_client_settings),
+            )
             .add_systems(Update, team_select_ui_system);
     }
 }
@@ -230,6 +233,7 @@ pub fn spawn_team_select_ui(commands: &mut Commands, selected_character: Charact
 
 fn team_select_ui_system(
     mut commands: Commands,
+    client_session: Res<ClientSession>,
     mut selection: ResMut<TeamSelection>,
     mut interaction_sets: ParamSet<(
         Query<
@@ -299,6 +303,9 @@ fn team_select_ui_system(
         for (interaction, button, mut color) in team_interactions.iter_mut() {
             match *interaction {
                 Interaction::Pressed => {
+                    if client_session.join_flow_committed {
+                        continue;
+                    }
                     selection.team = Some(button.team);
                     command_writer.write(NetworkCommand::Join {
                         team: button.team,

--- a/client/src/world.rs
+++ b/client/src/world.rs
@@ -61,13 +61,16 @@ pub struct SetupPlugin;
 
 impl Plugin for SetupPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, setup_scene)
-            .init_resource::<ModelScaleSettings>()
-            .init_resource::<LightingSettings>()
-            .add_systems(Update, sync_selected_player_assets)
-            .add_systems(Update, normalize_model_scale_system)
-            .add_systems(Update, apply_lighting_settings_system)
-            .add_systems(Update, spawn_local_player_on_team);
+        app.add_systems(
+            Startup,
+            setup_scene.after(crate::persistence::load_persistent_client_settings),
+        )
+        .init_resource::<ModelScaleSettings>()
+        .init_resource::<LightingSettings>()
+        .add_systems(Update, sync_selected_player_assets)
+        .add_systems(Update, normalize_model_scale_system)
+        .add_systems(Update, apply_lighting_settings_system)
+        .add_systems(Update, spawn_local_player_on_team);
     }
 }
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -11,9 +11,12 @@ Canonical version: `0.2.0`
 - Map layout with three lanes and simple jungle blocks.
 - Player progression with level-based XP thresholds, HP/mana scaling on level-up, and tracked skill points.
 - In-game local HUD display for level and XP progression.
+- Persistent local client preferences (graphics, character, optional server address) with safe clamping on load; override directory with `OMOBA_CLIENT_CONFIG_DIR` for tests or portable installs.
 
 ## Multiplayer Session Reliability
 
+- **TASK-14 (client)**: Explicit session states, non-blocking wait when the server is down, bounded `WaitingForServer` timeout, stale snapshot detection while connected, UDP transport error thresholds, snapshot-channel disconnect detection when the UDP thread ends, full teardown (replicated entities + team overlay) on disconnect, manual reconnect via **Retry** (no silent rejoin into a match), pause menu auto-closes on **Disconnected**, minimap hidden unless **Connected**.
+- Named timing constants and failure-detection summary: `docs/network-client-session.md` and `client/src/session_config.rs`.
 - Join is authoritative on the server: the client may optimistically pick a team and character, but the snapshot for `your_id` is the source of truth for spawn side, team, and character.
 - Repeated `Join` packets from the same UDP endpoint are deterministic: the last processed `Join` wins for team, character, spawn position, HP, mana, gold, and XP reset.
 - If a client stops sending packets, the server removes that player after `PLAYER_TIMEOUT = 5s`; remaining clients stop receiving that player in snapshots after the timeout expires.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -316,7 +316,9 @@ enum GameState {
     #[default]
     Lobby,
     Running,
-    Victory { winner: Team },
+    Victory {
+        winner: Team,
+    },
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -718,19 +720,17 @@ fn main() -> io::Result<()> {
             .values()
             .map(|player| player.state.id)
             .collect::<HashSet<_>>();
-        projectiles.retain(|_, projectile| {
-            match projectile.target.kind {
-                TargetKind::Player => live_player_ids.contains(&projectile.target.id),
-                TargetKind::Minion => minions
-                    .get(&projectile.target.id)
-                    .is_some_and(|minion| minion.state.hp > 0.0),
-                TargetKind::Structure => structures
-                    .get(&projectile.target.id)
-                    .is_some_and(|structure| structure.state.hp > 0.0),
-                TargetKind::Neutral => neutrals.get(&projectile.target.id).is_some_and(|neutral| {
-                    neutral.dead_until.is_none() && neutral.state.hp > 0.0
-                }),
-            }
+        projectiles.retain(|_, projectile| match projectile.target.kind {
+            TargetKind::Player => live_player_ids.contains(&projectile.target.id),
+            TargetKind::Minion => minions
+                .get(&projectile.target.id)
+                .is_some_and(|minion| minion.state.hp > 0.0),
+            TargetKind::Structure => structures
+                .get(&projectile.target.id)
+                .is_some_and(|structure| structure.state.hp > 0.0),
+            TargetKind::Neutral => neutrals
+                .get(&projectile.target.id)
+                .is_some_and(|neutral| neutral.dead_until.is_none() && neutral.state.hp > 0.0),
         });
 
         minions.retain(|_, minion| minion.state.hp > 0.0);
@@ -1200,8 +1200,7 @@ fn simulate_projectiles(
                     return false;
                 }
 
-                let start =
-                    Vec3f::new(projectile.state.x, projectile.state.y, projectile.state.z);
+                let start = Vec3f::new(projectile.state.x, projectile.state.y, projectile.state.z);
                 let target_pos = Vec3f::new(
                     target_neutral.state.x,
                     target_neutral.state.y + NEUTRAL_RADIUS * 0.85,
@@ -1300,9 +1299,10 @@ fn apply_neutral_damage(
         return;
     }
     neutral.state.hp = (neutral.state.hp - damage).max(0.0);
-    if players.values().any(|player| {
-        player.state.id == attacker_player_id && player.state.hp > 0.0
-    }) {
+    if players
+        .values()
+        .any(|player| player.state.id == attacker_player_id && player.state.hp > 0.0)
+    {
         neutral.target_player_id = Some(attacker_player_id);
         neutral.state.ai_state = NeutralAiState::Aggro;
     }
@@ -1384,15 +1384,12 @@ fn simulate_neutrals(
                 .values()
                 .filter(|player| player.state.hp > 0.0)
                 .map(|player| {
-                    let hit = Vec3f::new(player.state.x, player.state.y + AIM_HEIGHT, player.state.z);
+                    let hit =
+                        Vec3f::new(player.state.x, player.state.y + AIM_HEIGHT, player.state.z);
                     (player.state.id, neutral_pos.distance_squared(hit))
                 })
                 .filter(|(_, dist_sq)| *dist_sq <= aggro_sq)
-                .min_by(|a, b| {
-                    a.1
-                        .partial_cmp(&b.1)
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                });
+                .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
             if let Some((player_id, _)) = best {
                 neutral.target_player_id = Some(player_id);
                 neutral.state.ai_state = NeutralAiState::Aggro;
@@ -2209,9 +2206,7 @@ fn simulate_tower_attacks(
             let target_pos =
                 Vec3f::new(player.state.x, player.state.y + AIM_HEIGHT, player.state.z);
             let dist_sq = tower_position.distance_squared(target_pos);
-            if dist_sq <= range_sq
-                && best_target.is_none_or(|(_, _, best)| dist_sq < best)
-            {
+            if dist_sq <= range_sq && best_target.is_none_or(|(_, _, best)| dist_sq < best) {
                 best_target = Some((player.state.id, target_pos, dist_sq));
             }
         }


### PR DESCRIPTION
## Summary
- Finalize reconnect/session robustness with transport respawn and stale-signal protections.
- Keep the branch scoped to TASK-14 acceptance criteria and verifier outcomes.
- Preserve isolated worktree history for easier review.

## Test plan
- [x] Run branch build/test checks captured in task evidence.
- [x] Run a fresh verifier pass for TASK-14.
- [ ] Optional manual gameplay smoke before merge.

Made with [Cursor](https://cursor.com)