### PR TITLE
TASK-15: deliver runbook and playtest ops docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,14 @@ assets/
 .tasks
 AGENTS.md
 CLAUDE.md
-tasks/
-docs
+# docs/tasks: ignore by default; whitelist canonical markdown so deliverables stay versioned.
+docs/*
+!docs/features.md
+!docs/playtest-script.md
+!docs/bug-report-template.md
+!docs/mvp-scope-and-limitations.md
+!docs/progress/
+!docs/progress/**
+
+tasks/*
+!tasks/MVP-CHECKLIST.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The canonical repository version lives in `Cargo.toml` under `[workspace.package
 ## [Unreleased]
 
 ### Added
+- **TASK-15:** Playtest and ops documentation — root `README.md`, `docs/playtest-script.md` (10–20 minute session), `docs/bug-report-template.md`, `docs/mvp-scope-and-limitations.md`, `tasks/MVP-CHECKLIST.md` (MVP vs deferrable), expanded `RUNBOOK.md` troubleshooting with recovery steps, cross-links from `docs/features.md`, and `.gitignore` whitelists so these paths stay versioned (previously blanket-ignored).
 - Added a reproducible multiplayer session verification harness at `scripts/verify_task_02_multiplayer_session_flow.py` that exercises sequential and simultaneous joins, repeated joins, timeout cleanup, reconnect-as-new-player, server restart recovery, and four-client snapshot consistency against the live UDP server.
 - Added focused client coverage for authoritative local-player selection so duplicate local `Player` entities cannot silently break gameplay systems that rely on `Query::single()`.
 - Added multiplayer session policy documentation and a `TASK-02` progress log with the recorded session matrix.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+# omoba-bevy
+
+Authoritative-server MOBA-style prototype (Bevy client, Rust UDP server).
+
+## Prerequisites
+
+- [Rust toolchain](https://rustup.rs/) (`rustc`, `cargo`).
+- Git and a clone of this repository.
+
+## First-time setup
+
+From the **repository root** (the directory that contains this `README.md` and the `Makefile`):
+
+```sh
+cargo build --workspace
+```
+
+This compiles the `server` and `client` crates. Expect several minutes on the first run while dependencies build.
+
+## Run the game (happy path)
+
+All startup commands, environment variables, log expectations, and shutdown steps are documented in **[RUNBOOK.md](RUNBOOK.md)**.
+
+Typical local two-client session:
+
+```sh
+make start
+```
+
+Stop background processes afterward:
+
+```sh
+make stop
+```
+
+Do not rely on tribal knowledge for ports or addresses: use the tables in `RUNBOOK.md` (`SERVER_ADDR`, `GAME_SERVER_ADDR`).
+
+## Tester-facing documentation
+
+| Document | Purpose |
+| --- | --- |
+| [RUNBOOK.md](RUNBOOK.md) | Server/client startup, env vars, troubleshooting with recovery steps |
+| [docs/playtest-script.md](docs/playtest-script.md) | Timeboxed 10–20 minute MVP playtest checklist |
+| [docs/bug-report-template.md](docs/bug-report-template.md) | Expected internal bug report format |
+| [docs/mvp-scope-and-limitations.md](docs/mvp-scope-and-limitations.md) | MVP scope, limitations, MVP vs deferrable gaps |
+| [tasks/MVP-CHECKLIST.md](tasks/MVP-CHECKLIST.md) | MVP-blocking vs later improvements |
+
+## Controls and gameplay (MVP summary)
+
+| Input | Action |
+| --- | --- |
+| **W A S D** | Move camera when camera is unlocked (see below) |
+| **Mouse** | Look around when camera is unlocked |
+| **Mouse wheel** | Zoom when camera is locked |
+| **Right mouse** (hold) | Lock cursor for camera look; release to unlock |
+| **Alt** or **right click** (toggle) | Lock / unlock camera follow mode |
+| **Space** | Clear minimap camera focus override (when applicable) |
+| Team / character UI | Click team and character before play; server snapshot is authoritative |
+| **Tab** | Select nearest enemy target |
+| **Middle mouse** | Select target under cursor on the ground plane |
+| **Backspace** | Clear target |
+| **Q** | Cast at selected target (when match is running) |
+| On-screen **skill** button | Same as cast (when match is running) |
+| **Esc** | Pause menu |
+
+Gameplay: lane map, minions, structures, combat, respawn, match phases (lobby → running → victory / rematch), and progression HUD as described in [docs/features.md](docs/features.md).
+
+## Optional automated session check
+
+After a successful build, you can run the UDP session harness (separate port from the default Makefile flow):
+
+```sh
+python3 scripts/verify_task_02_multiplayer_session_flow.py
+```
+
+See the script header for prerequisites; it spawns its own server on `127.0.0.1:4010`.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -2,6 +2,8 @@
 
 Single-machine multiplayer testing for omoba-bevy.
 
+Entry point: see [README.md](README.md) for first-time setup and a controls summary. This file focuses on processes, logs, and recovery.
+
 ## Prerequisites
 
 - Rust toolchain (`rustup`) installed.
@@ -80,10 +82,14 @@ server is not running or is on a different address/port.
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `Address already in use` on server start | Previous server still running | `make stop` |
-| Client never receives first snapshot | Server not started or wrong port | Check `GAME_SERVER_ADDR` matches `SERVER_ADDR` |
-| `Failed to bind client UDP socket` | OS port exhaustion (rare) | Restart the client |
-| Client exits immediately | Build error or missing assets | Run `cargo build --workspace` and check for errors |
+| `Address already in use` on server start | Previous server still running | Run `make stop`; if it persists, find and terminate the process bound to the port (`lsof -i :4000` on macOS/Linux) and retry |
+| Client stuck on "Connecting…" / no snapshot | Server not running, wrong host, or firewall | 1) Confirm server log shows listening. 2) Ensure client `GAME_SERVER_ADDR` host and **port** match `SERVER_ADDR` (default `127.0.0.1:4000`). 3) Allow UDP for local binaries in OS firewall. 4) Retry `make restart` after `make stop` |
+| Client never receives first snapshot | Port mismatch between server bind and client target | Parse port from `SERVER_ADDR` (e.g. `0.0.0.0:5000` → clients use `127.0.0.1:5000` in `GAME_SERVER_ADDR`) |
+| Second machine on LAN cannot connect | Client still points at localhost | On the client machine set `GAME_SERVER_ADDR=<server-LAN-IP>:4000`; on the server keep `SERVER_ADDR=0.0.0.0:4000` so it accepts non-local interfaces |
+| `Connection refused` (tools) or immediate disconnect | Nothing listening on declared port | Start server first; verify with server log line; check VPN or corporate proxy is not blocking UDP loopback |
+| `Failed to bind client UDP socket` | OS port exhaustion (rare) | Close other clients; reboot if needed; retry `make game` |
+| Client exits immediately | Build error or asset load failure | Run `cargo build --workspace` from repo root and fix compile errors; check client stderr for asset path errors (the client uses `client/assets/` under the crate, including an auto-created downloads subfolder) |
+| `make stop` did not clear processes | Processes not started via `make start` | Manually kill `target/debug/server` and `target/debug/client` (or `pkill -f target/debug/server` / `client`) then confirm the port is free |
 
 ## Repeated Restart Behavior
 

--- a/docs/bug-report-template.md
+++ b/docs/bug-report-template.md
@@ -1,0 +1,41 @@
+# Internal bug report template (copy into issue or chat)
+
+Copy the block below. Replace bracketed fields. Attach logs if possible.
+
+```text
+## Summary
+[One line: what went wrong]
+
+## Environment
+- OS / version:
+- GPU / driver (if graphics or crash):
+- Git commit / branch:
+- Rust version (`rustc -V`):
+
+## MVP impact (required)
+- [ ] MVP-blocking (prevents playtest goals in docs/playtest-script.md)
+- [ ] Deferrable (nice-to-have; see tasks/MVP-CHECKLIST.md)
+
+## Reproduction
+1. [Exact steps, including commands e.g. make start]
+2. [...]
+
+## Expected
+[What the docs say should happen]
+
+## Actual
+[What you observed]
+
+## Logs / screenshots
+- Server log snippet:
+- Client log snippet:
+- Screenshot (if UI/graphics):
+
+## Recovery attempted
+[Which RUNBOOK.md troubleshooting steps you tried and outcome]
+```
+
+## Report quality bar
+
+- Include **commands** and **environment variables** if you changed defaults (`SERVER_ADDR`, `GAME_SERVER_ADDR`).
+- One bug per report when possible; link related issues instead of mixing topics.

--- a/docs/features.md
+++ b/docs/features.md
@@ -25,6 +25,13 @@ Canonical version: `0.2.0`
 
 - Runtime and startup stability hardening.
 - Full reconnect slot reclaim across disconnects and NAT changes.
-- Match phase, restart, and rematch flow.
-- Jungle camps and neutral AI.
-- Full skill system, tooltip UX, and release-readiness validation.
+- Expanded skill roster, tooltip UX, balance passes, and release-scale QA beyond the current cast-and-HUD surface.
+
+## Operations and playtest documentation
+
+- [README.md](../README.md) — setup, controls summary, links to tester docs.
+- [RUNBOOK.md](../RUNBOOK.md) — startup, env vars, troubleshooting with recovery steps.
+- [docs/playtest-script.md](playtest-script.md) — timeboxed MVP session checklist.
+- [docs/bug-report-template.md](bug-report-template.md) — internal report format.
+- [docs/mvp-scope-and-limitations.md](mvp-scope-and-limitations.md) — explicit MVP scope and limitations.
+- [tasks/MVP-CHECKLIST.md](../tasks/MVP-CHECKLIST.md) — MVP-blocking vs deferrable classification.

--- a/docs/mvp-scope-and-limitations.md
+++ b/docs/mvp-scope-and-limitations.md
@@ -1,0 +1,27 @@
+# MVP scope, limitations, and non-goals
+
+This page states what the **current MVP build** is intended to cover. It complements the live feature list in [features.md](features.md).
+
+## In scope for this MVP documentation
+
+- Local and same-LAN-style testing via documented `Makefile` targets and env vars.
+- Human playtest procedure ([playtest-script.md](playtest-script.md)) and comparable bug reports ([bug-report-template.md](bug-report-template.md)).
+- Explicit separation of **MVP-blocking** versus **deferrable** gaps ([tasks/MVP-CHECKLIST.md](../tasks/MVP-CHECKLIST.md)).
+
+## Known limitations (explicit)
+
+- **Reconnect identity:** A new UDP endpoint is treated as a new player; slot reclaim and persistent identity across disconnects are not implemented (see [features.md](features.md) → Multiplayer Session Reliability).
+- **Server restart:** Clients that stay open after a server restart need to send `Join` again for team/character; behavior is documented, not seamless reconnect.
+- **Player timeout:** Idle clients are dropped from snapshots after server `PLAYER_TIMEOUT` (~5s); this is intentional for this version.
+- **Operations:** No production SLOs, on-call runbooks, or hosted infrastructure; documentation targets developers and internal testers on their own machines.
+- **Balance and content:** Tuning, full skill UX, and release-scale QA are ongoing; the checklist marks what blocks external MVP versus backlog.
+
+## Non-goals (not promised in this MVP)
+
+- Full production deployment, auth, matchmaking at scale, or anti-cheat.
+- Exhaustive API or design documentation beyond what testers need to run and report.
+- Replacing automated tests; scripts and `cargo test` complement manual playtest.
+
+## Contradictions
+
+If `README.md`, `RUNBOOK.md`, or this file disagrees with **observed behavior**, treat the **code and Makefile** as the temporary source of truth and file an **MVP-blocking** doc bug.

--- a/docs/playtest-script.md
+++ b/docs/playtest-script.md
@@ -1,0 +1,58 @@
+# MVP playtest script (10–20 minutes)
+
+Use this checklist in **one sitting** with a clean shell. Follow [RUNBOOK.md](../RUNBOOK.md) for commands and [README.md](../README.md) for controls.
+
+**Goal:** Confirm the MVP build launches, connects, and is playable for a short session without undocumented steps.
+
+---
+
+## Before you start (about 2 minutes)
+
+- [ ] Read `README.md` prerequisites and run `cargo build --workspace` if you have not built yet.
+- [ ] Close stray game processes from earlier runs: `make stop`.
+- [ ] Note your OS and GPU/driver version for the bug template if anything graphics-related fails.
+
+**Expected:** Workspace builds without errors; `make stop` exits cleanly.
+
+---
+
+## Session A — Launch and connection (about 4–6 minutes)
+
+- [ ] From the repo root, run `make start`.
+- [ ] Confirm the **server** terminal shows a listening line for `0.0.0.0:4000` (or your overridden `SERVER_ADDR`).
+- [ ] Confirm **both clients** eventually log `First snapshot received` (see `RUNBOOK.md` → Expected Startup Log Output).
+- [ ] On each client window, complete **team** and **character** selection so both players spawn.
+
+**Expected:** Two windows respond to input; no infinite hang on “Connecting…” after the server is up.
+
+**If blocked:** Use the troubleshooting table in `RUNBOOK.md` (port mismatch, stale processes, wrong `GAME_SERVER_ADDR`).
+
+---
+
+## Session B — Match flow and basic combat (about 5–8 minutes)
+
+- [ ] Verify the match leaves the lobby overlay and enters **running** gameplay for both clients.
+- [ ] Move the camera (locked vs unlocked per `README.md`) and confirm the view follows your hero in locked mode.
+- [ ] Select a target with **Tab** or **middle mouse**, then cast with **Q** or the on-screen skill button; repeat at least twice.
+- [ ] Engage minions or structures long enough to see **damage**, **death/respawn**, or **base** pressure (no strict win required).
+- [ ] If time allows, trigger **victory** or **rematch** UI by playing toward a base kill or waiting for a decisive outcome.
+
+**Expected:** Abilities fire when a valid target exists; HUD shows progression fields consistent with [docs/features.md](features.md); victory/rematch overlays appear when the match ends.
+
+---
+
+## Session C — Clean shutdown (about 1–2 minutes)
+
+- [ ] Stop foreground client with **Ctrl+C** if needed, then run `make stop` from the repo root.
+- [ ] Confirm no `server` / `client` processes remain (Activity Monitor / Task Manager / `ps` as you prefer).
+
+**Expected:** Port 4000 is free for a subsequent `make start`.
+
+---
+
+## After the session
+
+- [ ] File notes using [bug-report-template.md](bug-report-template.md).
+- [ ] Mark whether each issue is **MVP-blocking** or **deferrable** using [tasks/MVP-CHECKLIST.md](../tasks/MVP-CHECKLIST.md).
+
+**Total time:** Approximately **12–18 minutes** at normal pace; stay within **20 minutes** by skipping optional victory/rematch if needed.

--- a/docs/progress/2026-04-01-task-15-runbook-docs-and-playtest-ops.md
+++ b/docs/progress/2026-04-01-task-15-runbook-docs-and-playtest-ops.md
@@ -1,0 +1,26 @@
+# Progress: TASK-15 runbook docs and playtest ops
+
+**Date:** 2026-04-01  
+**Task ID:** TASK-15  
+**Goal:** Documentation-only deliverables so testers can run, verify, and report without reverse-engineering the repo.
+
+## Changes
+
+- Added `README.md` with setup, happy-path pointers to `RUNBOOK.md`, controls summary, and tester doc index.
+- Added `docs/playtest-script.md` (timeboxed 10–20 minute checklist).
+- Added `docs/bug-report-template.md` and `docs/mvp-scope-and-limitations.md`.
+- Added `tasks/MVP-CHECKLIST.md` for MVP-blocking vs deferrable labeling.
+- Expanded `RUNBOOK.md` troubleshooting with concrete recovery steps (ports, LAN, firewall, stale processes).
+- Linked documentation from `docs/features.md`; logged in `CHANGELOG.md` under Unreleased.
+
+## Checks run
+
+- `cargo build --workspace`
+- `cargo test -p client` (5 tests; client has no separate lib target)
+- `cargo test -p server` (10 tests)
+- `cargo clippy --workspace --all-targets -- -D warnings` — **fails** on pre-existing server lints (`clippy::items_after_test_module`, `clippy::too_many_arguments` in `server/src/main.rs`); doc task does not change production code to fix.
+
+## Risks / follow-ups
+
+- AC1 blind “doc-only” walkthrough should be assigned to a reader with no prior context per the frozen spec verification plan; this session focused on doc completeness and command sanity.
+- 2026-04-02 finalize: `.gitignore` updated so `docs/*` / `tasks/*` deliverables are trackable; `docs/features.md` release-gap list aligned with shipped match lifecycle / jungle / neutrals; `RUNBOOK.md` asset troubleshooting line aligned with `client/assets` behavior.

--- a/tasks/MVP-CHECKLIST.md
+++ b/tasks/MVP-CHECKLIST.md
@@ -1,0 +1,25 @@
+# MVP checklist — blocking vs deferrable
+
+Use **MVP-blocking** for issues that stop a tester from completing [docs/playtest-script.md](../docs/playtest-script.md) using only [README.md](../README.md) and [RUNBOOK.md](../RUNBOOK.md).
+
+Use **Later / deferrable** for improvements that do not block the documented playtest path.
+
+## MVP-blocking (examples)
+
+- [ ] `cargo build --workspace` fails on a supported setup without documented workarounds.
+- [ ] Documented `make start` / `make stop` flow broken or inconsistent with actual ports/process cleanup.
+- [ ] Client cannot obtain first snapshot on localhost when following `RUNBOOK.md` exactly.
+- [ ] Match cannot enter **running** state from lobby with two local clients under documented steps.
+- [ ] Crash or hang that prevents finishing the playtest script in under 20 minutes.
+
+## Later / deferrable (examples)
+
+- [ ] Reconnect slot reclaim and NAT-persistent identity ([docs/features.md](../docs/features.md)).
+- [ ] Full skill tooltip UX and advanced balance passes.
+- [ ] Hosted server, metrics dashboards, on-call procedures.
+- [ ] Cosmetic polish, non-blocking UI glitches, and performance optimizations that still meet basic playability.
+
+## How to label issues
+
+- Tag or title prefix: **`mvp-blocker`** vs **`backlog`** (or your tracker’s equivalent).
+- In prose reports, use the **MVP impact** section in [docs/bug-report-template.md](../docs/bug-report-template.md).


### PR DESCRIPTION
## Summary
- Provide tester-facing runbook, playtest script, and MVP triage docs for reproducible validation.
- Keep the branch scoped to TASK-15 acceptance criteria and verifier outcomes.
- Preserve isolated worktree history for easier review.

## Test plan
- [x] Run branch build/test checks captured in task evidence.
- [x] Run a fresh verifier pass for TASK-15.
- [ ] Optional manual gameplay smoke before merge.

Made with [Cursor](https://cursor.com)