### PR TITLE
Set up development environment for omoba-bevy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+**omoba-bevy** is a multiplayer MOBA-style game built with the Bevy engine (Rust). The Cargo workspace has three crates:
+
+| Crate | Purpose |
+|---|---|
+| `shared` | Shared types (abilities, skill slots) used by both client and server |
+| `server` | Authoritative UDP game server (binds `0.0.0.0:4000` by default) |
+| `client` | Bevy 3D game client (connects to server over UDP) |
+
+No external services (databases, Docker, etc.) are required. All server state is in-memory.
+
+### System dependencies (pre-installed in snapshot)
+
+The following apt packages are required for building (especially for Bevy/OpenSSL):
+
+```
+libssl-dev pkg-config libudev-dev libasound2-dev libxkbcommon-dev libwayland-dev libvulkan-dev
+```
+
+Rust edition 2024 requires **Rust 1.85+**. The snapshot has `stable` (1.94+) set as the default toolchain via `rustup`.
+
+### Build / Test / Run
+
+See `RUNBOOK.md` for full local development instructions. Quick reference:
+
+| Action | Command |
+|---|---|
+| Build workspace | `cargo build --workspace` |
+| Test (all) | `cargo test --workspace` |
+| Lint (clippy) | `cargo clippy --workspace` |
+| Format check | `cargo fmt --check` |
+| Start server only | `make server` (or `cargo run -p server`) |
+| Start one client | `make game` (or `cargo run -p client`) |
+| Start server + 2 clients | `make start` |
+| Stop all processes | `make stop` |
+| Python test harness | `python3 scripts/verify_task_02_multiplayer_session_flow.py` (needs running server on port 4010) |
+
+### Known issue: main branch compilation errors
+
+As of the latest main merge, `server` and `client` crates have code-level compilation errors from bad merges:
+
+- **server**: duplicate function definitions (`handle_respawns`, `reset_match`), missing constants (`MAX_MELEE_SKILL_RANK`, `MELEE_BASE_DAMAGE`, etc.), wrong field names (`pending_ability_feedback` vs `pending_skill_feedback`, `last_ranged_shot_at`), and a missing function (`try_ranged_shot_ability`).
+- **client**: syntax error in `client/src/net.rs` line 978 (`))` instead of `})`).
+
+The `shared` crate compiles and passes all tests cleanly. These are code issues, not environment issues.
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `SERVER_ADDR` | `0.0.0.0:4000` | Address the server binds to |
+| `GAME_SERVER_ADDR` | `127.0.0.1:4000` | Server address clients connect to |
+
+### Client display requirement
+
+The Bevy client requires a GPU/display. On headless Cloud Agent VMs, use `Xvfb` or similar virtual framebuffer to run the client. The server runs headlessly without issues.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for the omoba-bevy multiplayer MOBA game.

### What was set up

- **Rust toolchain**: Updated from 1.83 to stable (1.94.1) — required for `edition = "2024"` (needs Rust 1.85+)
- **System dependencies**: Installed `libssl-dev`, `pkg-config`, `libudev-dev`, `libasound2-dev`, `libxkbcommon-dev`, `libwayland-dev`, `libvulkan-dev` for Bevy/OpenSSL compilation
- **`AGENTS.md`**: Created with Cloud-specific instructions covering build/test/run commands, system deps, known issues, and environment variables

### Environment verification

| Check | Result |
|---|---|
| `cargo build -p shared` | Pass |
| `cargo test -p shared` | Pass (2/2 tests) |
| `cargo clippy -p shared -- -D warnings` | Pass |
| `cargo build --workspace` | Fails — code compilation errors on `main` (bad merges, not env issues) |

### Known code issues on `main`

The `server` and `client` crates have compilation errors from bad merges (not environment-related):
- **server**: duplicate function definitions, missing constants, wrong field names
- **client**: syntax error in `net.rs` (`))` instead of `})`  on line 978)

The `shared` crate compiles and passes all tests cleanly.

### Build report

[full_build_report.log](https://cursor.com/agents/bc-86d9520a-2dbb-4624-9130-256c11d22b8a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffull_build_report.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86d9520a-2dbb-4624-9130-256c11d22b8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86d9520a-2dbb-4624-9130-256c11d22b8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

